### PR TITLE
chore: add avm-ptn-aiml-ai-foundry metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -1,4 +1,5 @@
 moduleId,providerNamespace,providerResourceType,moduleDisplayName,alternativeNames,primaryOwnerGitHubHandle,primaryOwnerDisplayName,secondaryOwnerGitHubHandle,secondaryOwnerDisplayName
+avm-ptn-aiml-ai-foundry,,,Azure AI Foundry Pattern,,mikestiers,Mike Stiers,,
 avm-ptn-aks-dev,,,AKS dev,,ms-henglu,Heng Lu,,
 avm-ptn-aks-economy,,,AKS economy,,ms-henglu,Heng Lu,,
 avm-ptn-aks-enterprise,,,AKS Enterprise,,ms-henglu,Heng Lu,,


### PR DESCRIPTION
This PR adds metadata for the avm-ptn-aiml-ai-foundry module.