### PR TITLE
chore: add avm-ptn-aiml-landing-zone metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -1,5 +1,6 @@
 moduleId,providerNamespace,providerResourceType,moduleDisplayName,alternativeNames,primaryOwnerGitHubHandle,primaryOwnerDisplayName,secondaryOwnerGitHubHandle,secondaryOwnerDisplayName
 avm-ptn-aiml-ai-foundry,,,Azure AI Foundry Pattern,,mikestiers,Mike Stiers,,
+avm-ptn-aiml-landing-zone,,,Azure AI and ML Landing Zone,,mbilalamjad,Bilal Amjad,,
 avm-ptn-aks-dev,,,AKS dev,,ms-henglu,Heng Lu,,
 avm-ptn-aks-economy,,,AKS economy,,ms-henglu,Heng Lu,,
 avm-ptn-aks-enterprise,,,AKS Enterprise,,ms-henglu,Heng Lu,,


### PR DESCRIPTION
This PR adds metadata for the avm-ptn-aiml-landing-zone module.