### PR TITLE
chore: add avm-res-hybridcompute-machine metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -74,6 +74,7 @@ avm-res-devopsinfrastructure-pool,Microsoft.DevOpsInfrastructure,Pools,DevOps Po
 avm-res-documentdb-databaseaccount,Microsoft.DocumentDB,databaseAccount,CosmosDB Database Account,,bryansan-msft,Bryan Sanchez Pernia,,
 avm-res-edge-site,Microsoft.Edge,sites,Azure Arc Site manager,,xhy8759,Hangyu Xu,,
 avm-res-eventhub-namespace,Microsoft.EventHub,namespaces,Event Hub Namespace,,mbilalamjad,Bilal Amjad,,
+avm-res-hybridcompute-machine,Microsoft.HybridCompute,machines,Hybrid Compute Machine,,,,,
 avm-res-hybridcontainerservice-provisionedclusterinstance,Microsoft.HybridContainerService,provisionedClusterInstances,AKS Arc,,xhy8759,Hangyu Xu,,
 avm-res-insights-autoscalesetting,Microsoft.Insights,autoscalesettings,Auto scale settings,,chianw,Chian Wong,,
 avm-res-insights-component,Microsoft.Insights,components,Application Insight,,Jfolberth,John Folberth,,


### PR DESCRIPTION
This PR adds metadata for the avm-res-hybridcompute-machine module.