### PR TITLE
chore: add avm-res-eventgrid-domain metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -76,6 +76,7 @@ avm-res-devcenter-devcenter,Microsoft.DevCenter,devcenters,Dev Center,,cshea-msf
 avm-res-devopsinfrastructure-pool,Microsoft.DevOpsInfrastructure,Pools,DevOps Pools,,jaredfholgate,Jared Holgate,,
 avm-res-documentdb-databaseaccount,Microsoft.DocumentDB,databaseAccount,CosmosDB Database Account,,bryansan-msft,Bryan Sanchez Pernia,,
 avm-res-edge-site,Microsoft.Edge,sites,Azure Arc Site manager,,xhy8759,Hangyu Xu,,
+avm-res-eventgrid-domain,Microsoft.EventGrid,domains,EventGrid Domain,,fafriha,Farouk Friha,,
 avm-res-eventgrid-namespace,Microsoft.EventGrid,namespaces,EventGrid Namespace,,dassbernd,Berna Sandalli,,
 avm-res-eventgrid-systemtopic,Microsoft.EventGrid,systemTopics,EventGrid System Topic,,fafriha,Farouk Friha,,
 avm-res-eventgrid-topic,Microsoft.EventGrid,topics,EventGrid Topic,,fafriha,Farouk Friha,,


### PR DESCRIPTION
This PR adds metadata for the avm-res-eventgrid-domain module.