### PR TITLE
chore: add avm-res-alertsmanagement-actionrule metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -33,6 +33,7 @@ avm-ptn-policyassignment,,,Policy assignment,,steph409,Stephanie Lanius,bjornhof
 avm-ptn-subnets-nsgs-routes,,,Network Security Groups,NSG,swathialuganti,Swathi Aluganti Narasimhulu,,
 avm-ptn-virtualwan,,,Virtual WAN,vWAN,khushal08,Khush Kaviraj,,
 avm-ptn-vnetgateway,,,Virtual Network Gateway,VNET GW,luke-taylor,Luke Taylor,matt-FFFFFF,Matt White
+avm-res-alertsmanagement-actionrule,Microsoft.AlertsManagement,actionRules,Alert Action Rules,,JoeyBarnes,Joseph Barnes,ASHR4,Rhys Ash
 avm-res-analysisservices-server,Microsoft.AnalysisServices,servers,Analysis Services Server,,Bhavyasree08,Bhavyasree Damarla,,
 avm-res-apimanagement-service,Microsoft.ApiManagement,service,API Management Service,,swatilekhapaul,Swatilekha Paul,,
 avm-res-app-containerapp,Microsoft.App,containerApps,Container App,,lonegunmanb,Zijie He,,


### PR DESCRIPTION
This PR adds metadata for the avm-res-alertsmanagement-actionrule module.