### PR TITLE
chore: add avm-res-cache-redis-enterprise metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -50,6 +50,7 @@ avm-res-azurestackhci-virtualmachineinstance,Microsoft.AzureStackHCI,virtualMach
 avm-res-batch-batchaccount,Microsoft.Batch,batchAccounts,Batch Account,,ethanjenkins1,Ethan Jenkins,,
 avm-res-botservice-botservice,Microsoft.BotService,botServices,Bot Service,,salujamanish,Manish Saluja,,
 avm-res-cache-redis,Microsoft.Cache,Redis,Redis Cache,,jchancellor-ms,Jon Chancellor,,
+avm-res-cache-redis-enterprise,Microsoft.Cache,redisEnterprise,Redis Cached Enterprise,,Ankur1106,Ankur Sharma (HK),,
 avm-res-cdn-profile,Microsoft.Cdn,profiles,CDN Profile,,Poven795909,Poornima Venkataramanan,didayal-msft,Divyadeep Dayal
 avm-res-cognitiveservices-account,Microsoft.CognitiveServices,accounts,Cognitive Service,,lonegunmanb,Zijie He,,
 avm-res-communication-emailservice,Microsoft.Communication,emailServices,Email Communication Service,,lonegunmanb,Zijie He,,


### PR DESCRIPTION
This PR adds metadata for the avm-res-cache-redis-enterprise module.