### PR TITLE
chore: add avm-res-containerservice-fleets metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -65,6 +65,7 @@ avm-res-compute-virtualmachine,Microsoft.Compute,virtualMachines,Virtual Machine
 avm-res-compute-virtualmachinescaleset,Microsoft.Compute,virtualMachineScaleSets,Virtual Machine Scale Set,VMSS,terrymandin,Terry Mandin,marcelkmfst,Marcel Keller
 avm-res-containerinstance-containergroup,Microsoft.ContainerInstance,containerGroups,Container Instance,,sharmilamusunuru,Sharmila Musunuru,,
 avm-res-containerregistry-registry,Microsoft.ContainerRegistry,registries,Azure Container Registry (ACR),,Akashc0807,Akash Choudhary,,
+avm-res-containerservice-fleets,Microsoft.ContainerService,fleets,Azure Kubernetes Service Fleet,,didayal-msft,Divyadeep Dayal,,
 avm-res-containerservice-managedcluster,Microsoft.ContainerService,managedClusters,AKS managed clusters,,ibersanoMS,Isabelle Bersano,,
 avm-res-dashboard-grafana,Microsoft.Dashboard,grafana,Azure Managed Grafana,,khajour,Abdelaziz Khajour,,
 avm-res-databricks-accessconnector,Microsoft.Databricks,accessConnectors,Azure Databricks Access Connector,,,,,


### PR DESCRIPTION
This PR adds metadata for the avm-res-containerservice-fleets module.