### PR TITLE
feat: add `Makefile` under template repo into synced file list

### DIFF
--- a/grept-policies/synced_files.grept.hcl
+++ b/grept-policies/synced_files.grept.hcl
@@ -20,7 +20,8 @@ locals {
     "examples/.terraform-docs.yml",
     "LICENSE",
     "SECURITY.md",
-    "SUPPORT.md"
+    "SUPPORT.md",
+    "Makefile",
   ])
 }
 


### PR DESCRIPTION
If we'd like to migrate `avmmakefile` from the original repo into this one, or into a new repo in the future, we need to keep `Makefile` in sync for all AVM repos.