### PR TITLE
chore: add avm-res-network-trafficmanagerprofile metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -141,6 +141,7 @@ avm-res-network-publicipaddress,Microsoft.Network,publicIPAddresses,Public IP Ad
 avm-res-network-publicipprefix,Microsoft.Network,publicIPPrefixes,Public IP Prefix,,PmeshramPM,Pankaj Meshram,,
 avm-res-network-routetable,Microsoft.Network,routeTables,Route Table,UDR,adammontlake,Adam Montlake,,
 avm-res-network-serviceendpointpolicy,Microsoft.Network,serviceEndpointPolicies,Service Endpoint Policies,,,,,
+avm-res-network-trafficmanagerprofile,Microsoft.Network,trafficmanagerprofiles,Traffic Manager Profile,,AnubhaR94,Anubha Rana,,
 avm-res-network-virtualnetwork,Microsoft.Network,virtualNetworks,Virtual Network,VNET,jaredfholgate,Jared Holgate,,
 avm-res-operationalinsights-workspace,Microsoft.OperationalInsights,workspaces,Log Analytics workspace,,cshea-msft,Charles Shea,jensheerin,Jen Sheerin
 avm-res-oracledatabase-cloudexadatainfrastructure,Oracle.Database,cloudExadataInfrastructures,Oracle Exadata Infrastructure,,sihbher,Gerardo Reyes,terrymandin,Terry Mandin


### PR DESCRIPTION
This PR adds metadata for the avm-res-network-trafficmanagerprofile module.