### PR TITLE
feat: create dummy environment for jobs not requiring auth

### DIFF
--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -179,6 +179,9 @@ jobs:
             -e \
             TF_VAR_enable_telemetry \
             -e AVM_EXAMPLE=${{ matrix.example }} \
+            -w /src/examples \
+            -e TF_IN_AUTOMATION \
+            -e TF_VAR_enable_telemetry \
             -e ARM_SUBSCRIPTION_ID \
             -e ARM_TENANT_ID \
             -e ARM_CLIENT_ID \
@@ -242,7 +245,6 @@ jobs:
             -w /src/examples \
             -e TF_IN_AUTOMATION \
             -e TF_VAR_enable_telemetry \
-            -e AVM_MOD_PATH=/src \
             -e ARM_SUBSCRIPTION_ID \
             -e ARM_TENANT_ID \
             -e ARM_CLIENT_ID \

--- a/tf-repo-mgmt/repository_sync/github.rulesets.tf
+++ b/tf-repo-mgmt/repository_sync/github.rulesets.tf
@@ -15,13 +15,13 @@ resource "github_repository_ruleset" "main" {
     creation                = true
     deletion                = true
     required_linear_history = true
-    non_fast_forward = true
+    non_fast_forward        = true
 
     pull_request {
-      dismiss_stale_reviews_on_push = true
-      require_code_owner_review = true
-      required_approving_review_count = var.is_protected_repo ? 1 : 0
-      require_last_push_approval = var.is_protected_repo
+      dismiss_stale_reviews_on_push     = true
+      require_code_owner_review         = true
+      required_approving_review_count   = var.is_protected_repo ? 1 : 0
+      require_last_push_approval        = var.is_protected_repo
       required_review_thread_resolution = true
     }
   }

--- a/tf-repo-mgmt/repository_sync/github.tf
+++ b/tf-repo-mgmt/repository_sync/github.tf
@@ -59,3 +59,12 @@ resource "github_actions_environment_secret" "client_id" {
   secret_name     = "ARM_CLIENT_ID"
   plaintext_value = azapi_resource.identity.output.properties.clientId
 }
+
+# This environment is used for jobs that do not require authentication.
+# Due to the OIDC subject claim refs mandating that environment is included,
+# all jobs must be run in an environment whether they need authentication or not.
+resource "github_repository_environment" "dummy_no_approval" {
+  count       = var.manage_github_environment ? 1 : 0
+  environment = var.github_repository_no_approval_environment_name
+  repository  = data.github_repository.this.name
+}

--- a/tf-repo-mgmt/repository_sync/variables.tf
+++ b/tf-repo-mgmt/repository_sync/variables.tf
@@ -21,8 +21,14 @@ variable "github_repository_name" {
 
 variable "github_repository_environment_name" {
   type        = string
-  description = "Branch of the GitHub repository."
+  description = "Name of the environment used to store secrets for the test environment."
   default     = "test"
+}
+
+variable "github_repository_no_approval_environment_name" {
+  type        = string
+  description = "Name of the environment used as a dummy no approval environment."
+  default     = "empty-no-approval"
 }
 
 variable "github_core_team_name" {


### PR DESCRIPTION
One side-effect of enabling the environment in the subject claim is that every job in that workflow needs and environment set, otherwise GitHub cannot start it.

This adds a dummy environment that has no secrets & that requries no approval.