### PR TITLE
fix(porch): pr-check

### DIFF
--- a/.github/workflows/housekeeping-pr-cleanup.yml
+++ b/.github/workflows/housekeeping-pr-cleanup.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Clean up unmerged PRs that used to target PR head branch but now target main
         run: |
-          PULL_REQUESTS=$(gh pr list --repo Azure/avm-terraform-governance --base main --search "test: update mock module" --json number)
-          echo "$PULL_REQUESTS" | jq -r '.[] | .number' | xargs -I {} gh pr close {} --delete-branch --comment "Unmerged updates to mock modules closed as source PR is now merged."
+          PULL_REQUESTS=$(gh pr list --repo ${{ github.repository }} --base main --search "test: update mock module" --json number)
+          echo "$PULL_REQUESTS" | jq -r '.[] | .number' | xargs -I% gh pr close --repo ${{ github.repository }} % --delete-branch --comment "Unmerged updates to mock modules closed as source PR is now merged."
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/porch-configs/pr-check.porch.yaml
+++ b/porch-configs/pr-check.porch.yaml
@@ -1,6 +1,14 @@
 name: PR Check
 description: |
   This configuration file is used to run checks for Azure Verified Modules during pull requests.
+
+command_groups:
+  - name: avmfix
+    commands:
+      - type: shell
+        name: avmfix
+        command_line: avmfix -folder .
+
 commands:
   - type: shell
     name: Check for uncommitted changes
@@ -144,8 +152,9 @@ commands:
               fi
 
         # Check mapotf transforms have been applied
+        # We need to run mapotf and avmfix to ensure the diff is the same as the pre-commit hook
       - type: serial
-        name: check mapotf
+        name: check mapotf & avmfix
         commands:
           - type: copycwdtotemp
             name: Copy to temp
@@ -163,6 +172,31 @@ commands:
             name: mapotf clean
             command_line: mapotf clean-backup --tf-dir .
             runs_on_condition: always
+
+          - type: parallel
+            name: avmfix
+            commands:
+              - type: serial
+                name: root module
+                command_group: avmfix
+
+              - type: foreachdirectory
+                name: submodules
+                working_directory: "./modules"
+                depth: 1
+                mode: parallel
+                skip_on_not_exist: true
+                working_directory_strategy: "item_relative"
+                command_group: avmfix
+
+              - type: foreachdirectory
+                name: examples
+                working_directory: "./examples"
+                depth: 1
+                mode: parallel
+                skip_on_not_exist: true
+                working_directory_strategy: "item_relative"
+                command_group: avmfix
 
             # mapotf
           - type: shell


### PR DESCRIPTION
Adds in a avmfix step after mapotf transform, to ensure that the code formatting is correct and avoid a diff error on the pr-check workflow.

Tested in a module locally using `AVM_PORCH_REF` to use polices from this branch and works well.

Also finally sort out the housekeeping workflow