### PR TITLE
ci(managed-pr-check): remove CONTAINER_IMAGE from env to use default MCR image

### DIFF
--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -13,7 +13,6 @@ env:
   ARM_TENANT_ID_OVERRIDE: ${{ secrets.ARM_TENANT_ID_OVERRIDE }}
   ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
   ARM_USE_OIDC: "true"
-  CONTAINER_IMAGE: ghcr.io/azure/avm-terraform-governance:avm-latest
   FORCE_COLOR: 1
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SECRETS_CONTEXT: ${{ toJson(secrets) }}


### PR DESCRIPTION
Now that we are in the MCR we don't need the override the container image here.