### PR TITLE
feat(repo-gov): tag rules

### DIFF
--- a/tf-repo-mgmt/repository_sync/github.rulesets.tf
+++ b/tf-repo-mgmt/repository_sync/github.rulesets.tf
@@ -37,7 +37,7 @@ resource "github_repository_ruleset" "main" {
 }
 
 resource "github_repository_ruleset" "tag_deny_non_v" {
-  name        = "No version tags without 'v' prefix"
+  name        = "Only allow v tags"
   repository  = data.github_repository.this.name
   target      = "tag"
   enforcement = "active"


### PR DESCRIPTION
## Evidence of v tags not being able to be deleted

Requires that all tags match this expression: `v[0-9]*.[0-9]*.[0-9]*`

Workflow run: <https://github.com/Azure/avm-terraform-governance/actions/runs/16003843764>