### PR TITLE
feat: ensure all modules either doesn't require random or v3 compatible version

### DIFF
--- a/mapotf-configs/pre-commit/required_provider_versions.mptf.hcl
+++ b/mapotf-configs/pre-commit/required_provider_versions.mptf.hcl
@@ -3,7 +3,8 @@ data "terraform" this {
 }
 
 locals {
-  azapi_provider_version_valid = try(!semvercheck(data.terraform.this.required_providers.azapi.version, "2.3.999"), false) && try(semvercheck(data.terraform.this.required_providers.azapi.version, "2.999.999"), false)
+  azapi_provider_version_valid  = try(!semvercheck(data.terraform.this.required_providers.azapi.version, "2.3.999"), false) && try(semvercheck(data.terraform.this.required_providers.azapi.version, "2.999.999"), false)
+  random_provider_version_valid = try(!semvercheck(data.terraform.this.required_providers.random.version, "2.999.999"), true) && try(semvercheck(data.terraform.this.required_providers.random.version, "3.999.999"), true)
 }
 
 transform "update_in_place" azapi_provider_version {
@@ -17,4 +18,20 @@ transform "update_in_place" azapi_provider_version {
       }
     }
   }
+}
+
+transform "update_in_place" random_provider_version {
+  for_each             = !local.random_provider_version_valid ? toset([1]) : toset([])
+  target_block_address = "terraform"
+  asraw {
+    required_providers {
+      random = {
+        source  = "hashicorp/random"
+        version = "~> 3.0"
+      }
+    }
+  }
+  depends_on = [
+    transform.update_in_place.azapi_provider_version
+  ]
 }


### PR DESCRIPTION
We've encountered cases that user cannot combine multiple AVM modules together due to provider version conflict, after investigation we found that some modules used fixed versions for some providers in `terraform.required_providers` section.

This pr introduced a test on `terraform` block for all AVM Terraform modules, either no `random` or it used an open version constraint, like `~> 3.0`. If not, this mapotf policy would set the version to `~> 3.0`, which works for almost all cases.