### PR TITLE
fix: amend missing `devcontainer json` config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "image": "mcr.microsoft.com/azterraform:latest",
+
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--init",
+    "--network=host"
+  ],
+
+  "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "local",
+        "go.useLanguageServer": true,
+        "go.goroot": "/usr/local/go"
+      },
+      "extensions": [
+        "azapi-vscode.azapi",
+        "EditorConfig.EditorConfig",
+        "golang.Go",
+        "hashicorp.terraform"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The [`devcontainer.json`](https://github.com/Azure/avm-terraform-governance/blob/main/grept-policies/managed_files.grept.hcl#L8C20-L8C37) defined in grept policies is missing in this repo, this pr amended the file.