### PR TITLE
feat: enforce tffr1 version exact check

### DIFF
--- a/tflint-configs/avm.tflint.hcl
+++ b/tflint-configs/avm.tflint.hcl
@@ -65,6 +65,7 @@ rule "terraform_module_pinned_source" {
 
 rule "terraform_module_version" {
   enabled = true
+  exact = true
 }
 
 rule "terraform_naming_convention" {

--- a/tflint-configs/avm.tflint_example.hcl
+++ b/tflint-configs/avm.tflint_example.hcl
@@ -65,6 +65,7 @@ rule "terraform_module_pinned_source" {
 
 rule "terraform_module_version" {
   enabled = true
+  exact = true
 }
 
 rule "terraform_naming_convention" {

--- a/tflint-configs/avm.tflint_module.hcl
+++ b/tflint-configs/avm.tflint_module.hcl
@@ -65,6 +65,7 @@ rule "terraform_module_pinned_source" {
 
 rule "terraform_module_version" {
   enabled = true
+  exact = true
 }
 
 rule "terraform_naming_convention" {


### PR DESCRIPTION
Add the `exact = true` property to the `terraform_module_version` rule from tflint to enforce TFFR1

See: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_module_version.md