### PR TITLE
feat: implement phased rollout for migration to new governance

### DIFF
--- a/.github/workflows/pre-commit-cron.yml
+++ b/.github/workflows/pre-commit-cron.yml
@@ -161,7 +161,6 @@ jobs:
       - name: run migrate
         if: steps.check.outputs.continue && steps.migrate-eligibility.outputs.run_migrate == 'true'
         run: |
-
           ./avm migrate
         shell: bash
         continue-on-error: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/pre-commit-cron.yml` file to introduce a rollout mechanism for a migration step and modifies the cron schedule for workflow execution. The changes add functionality to calculate repository eligibility for the migration based on a configurable rollout percentage and include the migration step conditionally.

### Workflow Enhancements:

* **Added `migrate_rollout_percentage` input:** Introduced a new input parameter to specify the percentage of repositories eligible for the migration step. This input is required and defaults to 20%.

* **Implemented rollout eligibility calculation:** Added a step to determine whether a repository is included in the migration rollout based on a deterministic hash of the repository name and the configured rollout percentage. Repositories are categorized into buckets, and only those within the rollout percentage are eligible.

* **Conditional migration step:** Added a step to execute the migration (`./avm migrate`) only if the repository is eligible based on the rollout calculation. This step uses the output from the eligibility calculation to decide whether to proceed.

### Schedule Update:

* **Updated cron schedule:** Adjusted the workflow's schedule to run on Monday, Thursday, and Sunday instead of Wednesday, Friday, and Sunday.

### Testing Evidence

- success (test repo has hash bucket == 1, workflow set to 2) <https://github.com/Azure/avm-terraform-governance/actions/runs/16328762925/job/46125707518>
- skip (test repo has hash bucket == 1, workflow set to 1) <https://github.com/Azure/avm-terraform-governance/actions/runs/16328415443/job/46124539311>
- PR merged on example repo <https://github.com/Azure/terraform-azurerm-avm-ptn-example-repo/pull/3>