### PR TITLE
feat(makefile): migrate target as no-op

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ AVM_PORCH_REF := main
 help:
 	@echo "please use 'make <target>'"
 
+.PHONY: migrate
+migrate:
+  @echo "This is a no-op. This repo has already been migrated."
+
 .PHONY: pre-commit
 pre-commit:
 	@echo "Running pre-commit..."

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 .PHONY: migrate
 migrate:
-  @echo "This is a no-op. This repo has already been migrated."
+	@echo "This is a no-op. This repo has already been migrated."
 
 .PHONY: pre-commit
 pre-commit:

--- a/tests/terraform-azure-avm-res-mock/.devcontainer/devcontainer.json
+++ b/tests/terraform-azure-avm-res-mock/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": " mcr.microsoft.com/public/azterraform:avm-latest",
+  "image": "mcr.microsoft.com/azterraform:avm-latest",
   "updateRemoteUserUID": true,
   "containerUser": "1000",
   "runArgs": [],
@@ -11,6 +11,7 @@
         "terraform.languageServer.terraform.path": "/home/runtimeuser/tfenv/bin/terraform"
       },
       "extensions": [
+        "azapi-vscode.azapi",
         "EditorConfig.EditorConfig",
         "hashicorp.terraform"
       ]

--- a/tests/terraform-azure-avm-res-mock/main.telemetry.tf
+++ b/tests/terraform-azure-avm-res-mock/main.telemetry.tf
@@ -23,6 +23,7 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 
+
 }
 locals {
   fork_avm = !anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
@@ -36,6 +37,7 @@ locals {
     "git::ssh:://git@github\\.com/[A|a]zure/.+",
   ]
 
+
 }
 
 locals {
@@ -48,6 +50,7 @@ locals {
     avm_module_source  = one(data.modtm_module_source.telemetry).module_source
     avm_module_version = one(data.modtm_module_source.telemetry).module_version
   })
+
 
 }
 

--- a/tests/terraform-azurerm-avm-res-mock/.devcontainer/devcontainer.json
+++ b/tests/terraform-azurerm-avm-res-mock/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": " mcr.microsoft.com/public/azterraform:avm-latest",
+  "image": "mcr.microsoft.com/azterraform:avm-latest",
   "updateRemoteUserUID": true,
   "containerUser": "1000",
   "runArgs": [],
@@ -11,6 +11,7 @@
         "terraform.languageServer.terraform.path": "/home/runtimeuser/tfenv/bin/terraform"
       },
       "extensions": [
+        "azapi-vscode.azapi",
         "EditorConfig.EditorConfig",
         "hashicorp.terraform"
       ]

--- a/tests/terraform-azurerm-avm-res-mock/main.telemetry.tf
+++ b/tests/terraform-azurerm-avm-res-mock/main.telemetry.tf
@@ -19,6 +19,7 @@ resource "modtm_telemetry" "telemetry" {
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
+
 }
 locals {
   main_location = var.location
@@ -31,6 +32,7 @@ locals {
     "git::https://github\\.com/[A|a]zure/.+",
     "git::ssh:://git@github\\.com/[A|a]zure/.+",
   ]
+
 }
 
 locals {
@@ -47,6 +49,7 @@ locals {
     avm_module_source  = one(data.modtm_module_source.telemetry).module_source
     avm_module_version = one(data.modtm_module_source.telemetry).module_version
   })
+
 }
 
 locals {


### PR DESCRIPTION
This pull request adds a new `migrate` target to the `Makefile`. The target is a no-op, indicating that the repository has already been migrated.