### PR TITLE
fix: pre-commit cron

### DIFF
--- a/.github/workflows/pre-commit-cron.yml
+++ b/.github/workflows/pre-commit-cron.yml
@@ -207,7 +207,7 @@ jobs:
         if: steps.check.outputs.continue && steps.changes.outputs.pr_url != ''
         run: |
           # Close older pre-commit PRs
-          gh pr list --state open --base main --json url --jq '.[] | select(.title | startswith("chore: pre-commit updates")) | .url' | while read -r pr_url; do
+          gh pr list --state open --base main --json url,title --jq '.[] | select(.title | startswith("chore: pre-commit updates")) | .url' | while read -r pr_url; do
             if [[ "$pr_url" != "${{ steps.changes.outputs.pr_url }}" ]]; then
               echo "Closing older pre-commit PR $pr_url"
               gh pr close $pr_url --delete-branch


### PR DESCRIPTION
This pull request updates the `.github/workflows/pre-commit-cron.yml` file to improve workflow automation and ensure proper permissions for the `avm` script. Key changes include adding a step to close older pre-commit PRs and ensuring the `avm` script is executable before running it.

Enhancements to workflow automation:

* [`.github/workflows/pre-commit-cron.yml`](diffhunk://#diff-8abdd6bdc0a6b5250f544e12c3924e78736e5429011a0f1f96fa69e7e90ae8d4R200-R218): Added a step to close older pre-commit PRs to prevent duplication and streamline repository management.
* [`.github/workflows/pre-commit-cron.yml`](diffhunk://#diff-8abdd6bdc0a6b5250f544e12c3924e78736e5429011a0f1f96fa69e7e90ae8d4R200-R218): Added a line to output the URL of the newly created pre-commit PR to `GITHUB_OUTPUT` for better tracking.

Permission fixes for `avm` script:

* [`.github/workflows/pre-commit-cron.yml`](diffhunk://#diff-8abdd6bdc0a6b5250f544e12c3924e78736e5429011a0f1f96fa69e7e90ae8d4R164-R173): Added `chmod a+x ./avm` before executing `avm migrate` and `avm pre-commit` to ensure the script has the proper executable permissions.

### Testing Evidence

Closing an old PR:

https://github.com/Azure/avm-terraform-governance/actions/runs/16344675368/job/46175288387