### PR TITLE
fix: prevent race condition in pre-commit by installing Terraform before parallel job

### DIFF
--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           if [[ -s trivy.txt ]]; then
             {
-              echo "### Security Output"
+              echo "## Trivy Output"
               echo "<details><summary>Click to expand</summary>"
               echo ""
               echo '```terraform'

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -119,7 +119,7 @@ jobs:
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         with:
           image-ref: ${{ env.CONTAINER_IMAGE }}
-          exit-code: '1'
+          exit-code: 0
           ignore-unfixed: true
           hide-progress: true
           scanners: vuln
@@ -127,7 +127,6 @@ jobs:
         continue-on-error: true
 
       - name: Publish Trivy Output to Summary
-        if: steps.trivy.outcome == 'failure'
         run: |
           if [[ -s trivy.txt ]]; then
             {

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -124,7 +124,6 @@ jobs:
           hide-progress: true
           scanners: vuln
           output: trivy.txt
-        continue-on-error: true
 
       - name: Publish Trivy Output to Summary
         run: |

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -116,18 +116,30 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         id: trivy
-        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # 0.31.0
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         with:
           image-ref: ${{ env.CONTAINER_IMAGE }}
           exit-code: '1'
           ignore-unfixed: true
+          hide-progress: true
           scanners: vuln
+          output: trivy.txt
         continue-on-error: true
 
-      - name: Annotate job
+      - name: Publish Trivy Output to Summary
         if: steps.trivy.outcome == 'failure'
         run: |
-          echo "## [error]Trivy found vulnerabilities in the image. Please review the scan results." >> $GITHUB_STEP_SUMMARY
+          if [[ -s trivy.txt ]]; then
+            {
+              echo "### Security Output"
+              echo "<details><summary>Click to expand</summary>"
+              echo ""
+              echo '```terraform'
+              cat trivy.txt
+              echo '```'
+              echo "</details>"
+            } >> $GITHUB_STEP_SUMMARY
+          fi
 
   test-governance:
     runs-on: ubuntu-latest

--- a/porch-configs/pre-commit.porch.yaml
+++ b/porch-configs/pre-commit.porch.yaml
@@ -26,6 +26,12 @@ commands:
       fi
       mapotf transform --mptf-dir "$AVM_MPTF_URL" --tf-dir .
 
+    # installs Terraform using tfenv
+  - type: shell
+    name: install Terraform
+    command_line: |
+      terraform version
+
   - type: shell
     name: mapotf clean
     command_line: mapotf clean-backup --tf-dir .

--- a/tests/terraform-azure-avm-res-mock/main.telemetry.tf
+++ b/tests/terraform-azure-avm-res-mock/main.telemetry.tf
@@ -22,8 +22,6 @@ resource "modtm_telemetry" "telemetry" {
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
-
-
 }
 locals {
   fork_avm = !anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
@@ -36,8 +34,6 @@ locals {
     "git::https://github\\.com/[A|a]zure/.+",
     "git::ssh:://git@github\\.com/[A|a]zure/.+",
   ]
-
-
 }
 
 locals {
@@ -50,8 +46,6 @@ locals {
     avm_module_source  = one(data.modtm_module_source.telemetry).module_source
     avm_module_version = one(data.modtm_module_source.telemetry).module_version
   })
-
-
 }
 
 locals {

--- a/tests/terraform-azurerm-avm-res-mock/main.telemetry.tf
+++ b/tests/terraform-azurerm-avm-res-mock/main.telemetry.tf
@@ -19,7 +19,6 @@ resource "modtm_telemetry" "telemetry" {
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
-
 }
 locals {
   main_location = var.location
@@ -32,7 +31,6 @@ locals {
     "git::https://github\\.com/[A|a]zure/.+",
     "git::ssh:://git@github\\.com/[A|a]zure/.+",
   ]
-
 }
 
 locals {
@@ -49,7 +47,6 @@ locals {
     avm_module_source  = one(data.modtm_module_source.telemetry).module_source
     avm_module_version = one(data.modtm_module_source.telemetry).module_version
   })
-
 }
 
 locals {


### PR DESCRIPTION
This pull request adds a new pre-commit command to install Terraform using `tfenv` in the `porch-configs/pre-commit.porch.yaml` file. 

This prevents a race condition where multiple parallel jobs are trying to do the same thing.

Key change:

* Added a new shell command (`install Terraform`) that checks the Terraform version, ensuring Terraform is installed and ready for use during pre-commit checks.

## Other changes

- Improved Trivy output on container build