### PR TITLE
fix: pre-commit & pr-check avmfix must be run serially

### DIFF
--- a/porch-configs/pr-check.porch.yaml
+++ b/porch-configs/pr-check.porch.yaml
@@ -173,7 +173,7 @@ commands:
             command_line: mapotf clean-backup --tf-dir .
             runs_on_condition: always
 
-          - type: parallel
+          - type: serial
             name: avmfix
             commands:
               - type: serial
@@ -184,7 +184,7 @@ commands:
                 name: submodules
                 working_directory: "./modules"
                 depth: 1
-                mode: parallel
+                mode: serial
                 skip_on_not_exist: true
                 working_directory_strategy: "item_relative"
                 command_group: avmfix
@@ -193,7 +193,7 @@ commands:
                 name: examples
                 working_directory: "./examples"
                 depth: 1
-                mode: parallel
+                mode: serial
                 skip_on_not_exist: true
                 working_directory_strategy: "item_relative"
                 command_group: avmfix

--- a/porch-configs/pre-commit.porch.yaml
+++ b/porch-configs/pre-commit.porch.yaml
@@ -36,7 +36,7 @@ commands:
     name: mapotf clean
     command_line: mapotf clean-backup --tf-dir .
 
-  - type: parallel
+  - type: serial
     name: avmfix
     commands:
       - type: serial
@@ -47,7 +47,7 @@ commands:
         name: submodules
         working_directory: "./modules"
         depth: 1
-        mode: parallel
+        mode: serial
         skip_on_not_exist: true
         working_directory_strategy: "item_relative"
         command_group: avmfix
@@ -56,7 +56,7 @@ commands:
         name: examples
         working_directory: "./examples"
         depth: 1
-        mode: parallel
+        mode: serial
         skip_on_not_exist: true
         working_directory_strategy: "item_relative"
         command_group: avmfix


### PR DESCRIPTION
This pull request modifies the execution mode and structure of commands in `porch-configs/pr-check.porch.yaml` and `porch-configs/pre-commit.porch.yaml` to ensure sequential processing. The changes primarily involve switching from parallel to serial execution for specific command groups and subcommands.

Execution mode changes in `porch-configs/pr-check.porch.yaml`:

* Changed the `type` of the `avmfix` command group from `parallel` to `serial`.  
* Updated the `mode` of the `submodules` command from `parallel` to `serial`.  
* Updated the `mode` of the `examples` command from `parallel` to `serial`.  

Execution mode changes in `porch-configs/pre-commit.porch.yaml`:

* Changed the `type` of the `avmfix` command group from `parallel` to `serial`.  
* Updated the `mode` of the `submodules` command from `parallel` to `serial`.  
* Updated the `mode` of the `examples` command from `parallel` to `serial`.