### PR TITLE
chore: add avm-ptn-aca-lza-hosting-environment metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -1,5 +1,5 @@
 moduleId,providerNamespace,providerResourceType,moduleDisplayName,alternativeNames,primaryOwnerGitHubHandle,primaryOwnerDisplayName,secondaryOwnerGitHubHandle,secondaryOwnerDisplayName
-avm-ptn-aca-lza-hosting-environment,,,,,sam-coga,Sam Cogan,,
+avm-ptn-aca-lza-hosting-environment,,,,,sam-cogan,Sam Cogan,,
 avm-ptn-aiml-ai-foundry,,,Azure AI Foundry Pattern,,mikestiers,Mike Stiers,,
 avm-ptn-aiml-landing-zone,,,Azure AI and ML Landing Zone,,mbilalamjad,Bilal Amjad,,
 avm-ptn-aks-dev,,,AKS dev,,ms-henglu,Heng Lu,,

--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -1,4 +1,5 @@
 moduleId,providerNamespace,providerResourceType,moduleDisplayName,alternativeNames,primaryOwnerGitHubHandle,primaryOwnerDisplayName,secondaryOwnerGitHubHandle,secondaryOwnerDisplayName
+avm-ptn-aca-lza-hosting-environment,,,,,sam-coga,Sam Cogan,,
 avm-ptn-aiml-ai-foundry,,,Azure AI Foundry Pattern,,mikestiers,Mike Stiers,,
 avm-ptn-aiml-landing-zone,,,Azure AI and ML Landing Zone,,mbilalamjad,Bilal Amjad,,
 avm-ptn-aks-dev,,,AKS dev,,ms-henglu,Heng Lu,,


### PR DESCRIPTION
This PR adds metadata for the avm-ptn-aca-lza-hosting-environment module.