### PR TITLE
feat(avm): mount host docker socket when using docker runtime

### DIFF
--- a/managed-files/root/avm
+++ b/managed-files/root/avm
@@ -48,6 +48,13 @@ if [ -d "${AZURE_CONFIG_DIR}" ]; then
   AZURE_CONFIG_MOUNT="-v ${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 fi
 
+# If CONTAINER_RUNTIME is docker, mount docker socket into container so the container can talk to the host docker daemon
+if [ "${CONTAINER_RUNTIME:-}" = "docker" ]; then
+  if [ -S /var/run/docker.sock ]; then
+    DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
+  fi
+fi
+
 # If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
 if [ -z "${GITHUB_RUN_ID}" ] && [ -z "${NO_COLOR}" ]; then
   TUI="--tui"
@@ -70,6 +77,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     ${DOCKER_INTERACTIVE} \
     -v "$(pwd)":/src \
     ${AZURE_CONFIG_MOUNT:-} \
+    ${DOCKER_SOCK_MOUNT:-} \
     -e ARM_CLIENT_ID \
     -e ARM_OIDC_REQUEST_TOKEN \
     -e ARM_OIDC_REQUEST_URL \

--- a/managed-files/root/avm
+++ b/managed-files/root/avm
@@ -48,11 +48,9 @@ if [ -d "${AZURE_CONFIG_DIR}" ]; then
   AZURE_CONFIG_MOUNT="-v ${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 fi
 
-# If CONTAINER_RUNTIME is docker, mount docker socket into container so the container can talk to the host docker daemon
-if [ "${CONTAINER_RUNTIME:-}" = "docker" ]; then
-  if [ -S /var/run/docker.sock ]; then
-    DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
-  fi
+# If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
+if [ -S /var/run/docker.sock ]; then
+  DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
 fi
 
 # If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode


### PR DESCRIPTION
Mount /var/run/docker.sock into the container when CONTAINER_RUNTIME=docker so containerized tasks can access the host Docker daemon. Only applies when the socket exists on the host.