### PR TITLE
feat: porch TUI flags plus makefile help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ AVM_PORCH_REF := main
 .PHONY: help
 help:
 	@echo "please use 'make <target>'"
+	@echo "available targets are:"
+	@echo "  help"
+	@echo "  migrate (a no-op, this repo has already been migrated)"
+	@echo "  pre-commit (runs doc generation and repo file sync)"
+	@echo "  pr-check (checks that pre-commit has been run and runs linters)"
+	@echo "  test-examples (set `AVM_EXAMPLE` to the specific example name to only test one)"
+	@echo "  tf-test-unit (runs unit tests in `tests/unit`)"
+	@echo "  tf-test-integration (runs integration tests in `tests/integration`)"
+	@echo "  globalsetup (runs global setup tasks, only if you have a `examples/setup.sh`)"
+	@echo "  globalteardown (runs global teardown tasks, only if you have a `examples/teardown.sh`)"
 
 .PHONY: migrate
 migrate:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "  migrate (a no-op, this repo has already been migrated)"
 	@echo "  pre-commit (runs doc generation and repo file sync)"
 	@echo "  pr-check (checks that pre-commit has been run and runs linters)"
-	@echo "  test-examples (set `AVM_EXAMPLE` to the specific example name to only test one)"
+	@echo "  test-examples (tests all examples - set `AVM_EXAMPLE` to the specific example name to only test one)"
 	@echo "  tf-test-unit (runs unit tests in `tests/unit`)"
 	@echo "  tf-test-integration (runs integration tests in `tests/integration`)"
 	@echo "  globalsetup (runs global setup tasks, only if you have a `examples/setup.sh`)"

--- a/managed-files/root/avm
+++ b/managed-files/root/avm
@@ -53,11 +53,25 @@ if [ -S /var/run/docker.sock ]; then
   DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
 fi
 
-# If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
-if [ -z "${GITHUB_RUN_ID}" ] && [ -z "${NO_COLOR}" ]; then
+# New: allow overriding TUI behavior with PORCH_FORCE_TUI and PORCH_NO_TUI environment variables.
+# - If PORCH_FORCE_TUI is set, force TUI and interactive mode (even in GH Actions).
+# - If PORCH_NO_TUI is set, explicitly disable TUI.
+# - Otherwise, fallback to previous behavior: enable TUI only when not in GitHub Actions and NO_COLOR is not set.
+if [ -n "${PORCH_FORCE_TUI}" ]; then
   TUI="--tui"
   DOCKER_INTERACTIVE="-it"
   export FORCE_COLOR=1
+elif [ -n "${PORCH_NO_TUI}" ]; then
+  # Explicitly disable TUI and interactive flags
+  TUI=""
+  DOCKER_INTERACTIVE=""
+else
+  # If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
+  if [ -z "${GITHUB_RUN_ID}" ] && [ -z "${NO_COLOR}" ]; then
+    TUI="--tui"
+    DOCKER_INTERACTIVE="-it"
+    export FORCE_COLOR=1
+  fi
 fi
 
 # if AVM_PORCH_BASE_URL is set, we want to add it to the make command

--- a/managed-files/root/avm.ps1
+++ b/managed-files/root/avm.ps1
@@ -47,13 +47,29 @@ if (Test-Path $AZURE_CONFIG_DIR) {
   $AZURE_CONFIG_MOUNT_PATH = "${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 }
 
-# If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
+# New: allow overriding TUI behavior with PORCH_FORCE_TUI and PORCH_NO_TUI environment variables.
+# - If PORCH_FORCE_TUI is set, force TUI and interactive mode (even in GH Actions).
+# - If PORCH_NO_TUI is set, explicitly disable TUI.
+# - Otherwise, fallback to previous behavior: enable TUI only when not in GitHub Actions and NO_COLOR is not set.
 $TUI = $null
 $DOCKER_INTERACTIVE = $null
-if (-not $env:GITHUB_RUN_ID -and -not $env:NO_COLOR) {
+if ($env:PORCH_FORCE_TUI -and $env:PORCH_FORCE_TUI -ne "") {
   $TUI = "--tui"
   $DOCKER_INTERACTIVE = "-it"
   $env:FORCE_COLOR = "1"
+}
+elseif ($env:PORCH_NO_TUI -and $env:PORCH_NO_TUI -ne "") {
+  # Explicitly disable TUI and interactive flags
+  $TUI = $null
+  $DOCKER_INTERACTIVE = $null
+}
+else {
+  # If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
+  if (-not $env:GITHUB_RUN_ID -and -not $env:NO_COLOR) {
+    $TUI = "--tui"
+    $DOCKER_INTERACTIVE = "-it"
+    $env:FORCE_COLOR = "1"
+  }
 }
 
 # if PORCH_BASE_URL is set, we want to add it to the make command


### PR DESCRIPTION
This pull request introduces improvements to both the developer experience and the flexibility of the AVM Porch tooling. The most significant changes are the addition of environment variable overrides for TUI (Text User Interface) mode and enhancements to the `Makefile` help output. These updates make it easier to control interactive behavior in different environments and clarify available `make` targets for users.

**TUI Behavior Overrides:**

* Added support for `PORCH_FORCE_TUI` and `PORCH_NO_TUI` environment variables in both `managed-files/root/avm` (bash) and `managed-files/root/avm.ps1` (PowerShell) scripts. This allows users to explicitly enable or disable TUI mode regardless of CI environment or color settings. (`[[1]](diffhunk://#diff-98bc6d99ffee2a9c5f3329e875c473e1e32dd1c8a580e3c4880e89f01200267bR56-R75)`, `[[2]](diffhunk://#diff-f8928a5de238e26fe2af57f51e15b48dc5af6bc16d167e667ae7de6352223b8bL50-R73)`)

**Developer Documentation and Usability:**

* Enhanced the `Makefile` help target to list all available make targets and provide brief descriptions, improving discoverability and onboarding for new contributors. (`[MakefileR7-R16](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R7-R16)`)