### PR TITLE
fix(container): cgo for legacy build

### DIFF
--- a/.github/workflows/legacy-container-test.yml
+++ b/.github/workflows/legacy-container-test.yml
@@ -1,0 +1,105 @@
+---
+name: legacy container test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - container/**
+  workflow_dispatch:
+
+concurrency:
+  group: legacy-container-test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CONTAINER_IMAGE: azterraform:test
+  FORCE_COLOR: 1
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+    environment: avm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b # v1.1.6
+        id: readenv
+        with:
+          path: ./container/version.env
+
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ secrets.AVM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
+
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            azterraform
+          tags: |
+            type=raw,value=test
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          version: latest
+
+      - name: Concat Dockerfiles
+        run: |
+          cat Dockerfile.build Dockerfile.azterraform > Dockerfile
+          rm -f Dockerfile.*
+        working-directory: ./container
+
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build image
+        id: push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./container
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ steps.readenv.outputs.content }}
+          outputs: type=docker
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Trivy vulnerability scanner
+        id: trivy
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
+        with:
+          image-ref: ${{ env.CONTAINER_IMAGE }}
+          exit-code: 0
+          ignore-unfixed: true
+          hide-progress: true
+          scanners: vuln
+          output: trivy.txt
+
+      - name: Publish Trivy Output to Summary
+        run: |
+          if [[ -s trivy.txt ]]; then
+            {
+              echo "## Trivy Output"
+              echo "<details><summary>Click to expand</summary>"
+              echo ""
+              echo '```terraform'
+              cat trivy.txt
+              echo '```'
+              echo "</details>"
+            } >> $GITHUB_STEP_SUMMARY
+          fi

--- a/container/Dockerfile.azterraform
+++ b/container/Dockerfile.azterraform
@@ -5,6 +5,7 @@ ARG PREVIOUS_TAG_VERSION=656b12a97270ca29998ad62e3564d08e7d4369ba
 ARG TARGETARCH
 # Cross compile go binaries
 ENV GOARCH=${TARGETARCH}
+ENV CGO_ENABLED=1
 RUN go install github.com/lonegunmanb/previousTag@$PREVIOUS_TAG_VERSION && \
   mkdir /src && \
   cd /src && \

--- a/tests/terraform-azure-avm-res-mock/.devcontainer/devcontainer.json
+++ b/tests/terraform-azure-avm-res-mock/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
         "terraform.languageServer.terraform.path": "/home/runtimeuser/tfenv/bin/terraform"
       },
       "extensions": [
-        "azapi-vscode.azapi",
+        "ms-azuretools.vscode-azureterraform",
         "EditorConfig.EditorConfig",
         "hashicorp.terraform"
       ]

--- a/tests/terraform-azurerm-avm-res-mock/.devcontainer/devcontainer.json
+++ b/tests/terraform-azurerm-avm-res-mock/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
         "terraform.languageServer.terraform.path": "/home/runtimeuser/tfenv/bin/terraform"
       },
       "extensions": [
-        "azapi-vscode.azapi",
+        "ms-azuretools.vscode-azureterraform",
         "EditorConfig.EditorConfig",
         "hashicorp.terraform"
       ]


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for legacy container testing and makes a minor update to the container build configuration. The workflow automates the building and vulnerability scanning of the container image, improving CI coverage and security checks for changes in the `container` directory.

**CI Workflow Additions:**

* Added `.github/workflows/legacy-container-test.yml` to automate building the azterraform container image, running Trivy vulnerability scans, and publishing scan results for pull requests affecting the `container` directory.

**Build Configuration Update:**

* Set `CGO_ENABLED=1` in `container/Dockerfile.azterraform` to enable CGO during Go builds, which may be required for certain dependencies or features.