### PR TITLE
ci: fix admin pre-commit command

### DIFF
--- a/.github/workflows/admin-merge-pre-commit-prs.yml
+++ b/.github/workflows/admin-merge-pre-commit-prs.yml
@@ -1,5 +1,5 @@
 ---
-name: pre-commit-cron
+name: admin-merge-pre-commit-prs
 
 on:
   workflow_dispatch:
@@ -71,7 +71,7 @@ jobs:
           for N in "${NOS[@]}"; do
             echo "Processing PR #$N"
             gh pr review "$N" --repo ${{ matrix.repoFullName }} --approve --body "Approved by admin-merge-pre-commit-prs workflow"
-            gh pr merge "$N" --repo ${{ matrix.repoFullName }} --merge --squash --delete-branch
+            gh pr merge "$N" --repo ${{ matrix.repoFullName }} --squash --delete-branch
           done
         env:
           GH_TOKEN: ${{ inputs.gh_token }}

--- a/.github/workflows/pre-commit-cron.yml
+++ b/.github/workflows/pre-commit-cron.yml
@@ -155,8 +155,16 @@ jobs:
           # Create a PR and merge it
           PRURL=$(gh pr create --base main --head pre-commit-${{ github.run_id }} --title "chore: pre-commit updates" --body "This PR contains pre-commit updates.")
           echo "pr_url=$PRURL" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: merge PR
+        if: steps.check.outputs.continue && steps.changes.outputs.pr_url != ''
+        run: |
           gh pr merge $PRURL --squash --admin --delete-branch
         shell: bash
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows related to pre-commit pull requests, focusing on improving the automation and permissions for merging PRs. The main changes include renaming a workflow for clarity, adjusting merge commands to better use admin privileges, and refining environment and error handling in the scripts.

**Workflow and automation improvements:**

* Renamed the workflow from `pre-commit-cron` to `admin-merge-pre-commit-prs` in `.github/workflows/admin-merge-pre-commit-prs.yml` for clearer identification of its purpose.

**Merge command and permissions adjustments:**

* Removed the redundant `--merge` flag from the `gh pr merge` command in `.github/workflows/admin-merge-pre-commit-prs.yml`, ensuring only the `--squash` merge method is used.
* In `.github/workflows/pre-commit-cron.yml`, added a dedicated step to merge PRs using the `--admin` flag for elevated permissions, and set `continue-on-error: true` to prevent workflow failures if the merge fails.

**Environment and shell configuration:**

* Explicitly set the shell to `bash` and ensured the correct `GH_TOKEN` environment variable is available for GitHub CLI commands in `.github/workflows/pre-commit-cron.yml`.