### PR TITLE
chore: add avm-res-management-servicegroup metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -125,6 +125,7 @@ avm-res-maintenance-maintenanceconfiguration,Microsoft.Maintenance,maintenanceCo
 avm-res-managedidentity-userassignedidentity,Microsoft.ManagedIdentity,userAssignedIdentities,User Assigned Identity,MSI,Jfolberth,John Folberth,,
 avm-res-managedservices-registrationdefinition,Microsoft.ManagedServices,registrationDefinitions,Managed Services Registration Definition,,,,,
 avm-res-management-managementgroup,Microsoft.Management,managementGroups,Management Groups,,herms14,Hermes Miraflor II,,
+avm-res-management-servicegroup,Microsoft.Management,serviceGroups,Management Service Groups,,jaredfholgate,Jared Holgate,,
 avm-res-netapp-netappaccount,Microsoft.NetApp,netAppAccounts,Azure NetApp File,,jtracey93,Jack Tracey,,
 avm-res-network-applicationgateway,Microsoft.Network,applicationGateways,Application Gateway,App GW,mofaizal,Mohamed Faizal,,
 avm-res-network-applicationgatewaywebapplicationfirewallpolicy,Microsoft.Network,ApplicationGatewayWebApplicationFirewallPolicies,Application Gateway Web Application Firewall (WAF) Policy,,mofaizal,Mohamed Faizal,,


### PR DESCRIPTION
This PR adds metadata for the avm-res-management-servicegroup module.