### PR TITLE
fix: relative directory for unit testing modules

### DIFF
--- a/porch-configs/terraform-test.porch.yaml
+++ b/porch-configs/terraform-test.porch.yaml
@@ -70,7 +70,7 @@ commands:
         mode: parallel
         skip_on_not_exist: true
         command_group: terraform_unit_tests
-        working_directory_strategy: "item_relative"
+        working_directory_strategy: item_relative
 
       - type: serial
         name: root module


### PR DESCRIPTION
Ensure the command runs in the module directory