### PR TITLE
chore: add skip condition for grept commands

### DIFF
--- a/porch-configs/pr-check.porch.yaml
+++ b/porch-configs/pr-check.porch.yaml
@@ -137,6 +137,11 @@ commands:
           - type: shell
             name: Grept apply
             command_line: |
+              if ! [ -z "$AVM_GREPT_SKIP" ]; then
+                echo "AVM_GREPT_SKIP is set. Continue."
+                exit 0
+              fi
+            
               if [ -z "$AVM_GREPT_URL" ]; then
                 AVM_GREPT_URL="git::https://github.com/Azure/avm-terraform-governance.git//grept-policies"
               fi
@@ -145,6 +150,11 @@ commands:
           - type: shell
             name: Check for grept changes
             command_line: |
+              if ! [ -z "$AVM_GREPT_SKIP" ]; then
+                echo "AVM_GREPT_SKIP is set. Continue."
+                exit 0
+              fi
+            
               if [ -n "$(git status --porcelain)" ]; then
                 echo "Grept changes found, run pre-commit" 1>&2
                 git status --porcelain 1>&2


### PR DESCRIPTION
Added checks for AVM_GREPT_SKIP environment variable to skip grept commands if set. This is to speed up the local dev cycle when iterating a lot to fix issues.