### PR TITLE
chore: add avm-utl-compute-orchestratedvirtualmachinescaleset-azapi-replicator metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -188,6 +188,7 @@ avm-res-web-hostingenvironment,Microsoft.Web,hostingEnvironments,App Service Env
 avm-res-web-serverfarm,Microsoft.Web,serverfarms,App Service Plan,,ibersanoMS,Isabelle Bersano,,
 avm-res-web-site,Microsoft.Web,sites,Web/Function App,"App Service, Web Site, Logic App, Function App",donovm4,Donovan McCoy,,
 avm-res-web-staticsite,Microsoft.Web,staticSites,Static Web App,,donovm4,Donovan McCoy,,
+avm-utl-compute-orchestratedvirtualmachinescaleset-azapi-replicator,,,utl module that helps users to migrate azurerm_orchestrated_virtual_machine_scale_set resource into azapi_resource,,lonegunmanb,lonegunmanb,,
 avm-utl-ephemeral-credential,,,AVM ephemeral credentials,,lonegunmanb,Zijie He,,
 avm-utl-interfaces,,,AVM Interfaces,,matt-FFFFFF,Matt White,,
 avm-utl-naming,,,AVM Naming,,Nepomuceno,Gabriel Monteiro Nepomuceno,,


### PR DESCRIPTION
This PR adds metadata for the avm-utl-compute-orchestratedvirtualmachinescaleset-azapi-replicator module.