### PR TITLE
[fix ext typo]

### DIFF
--- a/tests/terraform-azure-avm-res-mock/.vscode/extensions.json
+++ b/tests/terraform-azure-avm-res-mock/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "EditorConfig.EditorConfig",
     "hashicorp.terraform",
-    "ms-azurertools.vscode-azureterraform"
+    "ms-azuretools.vscode-azureterraform"
   ]
 }

--- a/tests/terraform-azurerm-avm-res-mock/.vscode/extensions.json
+++ b/tests/terraform-azurerm-avm-res-mock/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "EditorConfig.EditorConfig",
     "hashicorp.terraform",
-    "ms-azurertools.vscode-azureterraform"
+    "ms-azuretools.vscode-azureterraform"
   ]
 }


### PR DESCRIPTION
Fix typo in .vscode/extensions.json: `ms-azurertools` -> `ms-azuretools`