### PR TITLE
feat: wire test_no_approval environment name variable through repository_sync

### DIFF
--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -29,7 +29,7 @@ jobs:
       subscriptionName: ${{ steps.subscriptions.outputs.subscriptionName }}
       subscriptionsJson: ${{ steps.subscriptions.outputs.subscriptionsJson }}
     steps:
-      - name: Get Randomised Subscriptions 
+      - name: Get Randomised Subscriptions
         id: subscriptions
         run: |
           $subscriptions = $env:TEST_SUBSCRIPTION_IDs | ConvertFrom-Json
@@ -43,6 +43,7 @@ jobs:
           Write-Output "subscriptionName=$($defaultSubscription.name)" >> $env:GITHUB_OUTPUT
         env:
           TEST_SUBSCRIPTION_IDS: ${{ secrets.TEST_SUBSCRIPTION_IDS }}
+        shell: pwsh
 
   pr-check:
     if: github.event.pull_request.head.repo.fork == false
@@ -305,7 +306,7 @@ jobs:
     needs: [checkteardown, subscriptions]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      
+
       - name: Run teardown script
         run: |
           set -e

--- a/tf-repo-mgmt/repository_sync/main.tf
+++ b/tf-repo-mgmt/repository_sync/main.tf
@@ -17,24 +17,25 @@ module "azure" {
 module "github" {
   source = "./modules/github"
 
-  repository_creation_mode_enabled                = var.repository_creation_mode_enabled
-  github_repository_owner                         = var.github_repository_owner
-  github_repository_name                          = var.github_repository_name
-  github_repository_environment_name              = var.github_repository_environment_name
-  github_repository_no_approval_environment_name  = var.github_repository_no_approval_environment_name
-  github_repository_copilot_environment_name      = var.github_repository_copilot_environment_name
-  is_protected_repo                               = var.is_protected_repo
-  bypass_ruleset_for_approval_enabled             = true
-  github_teams                                    = var.github_teams
-  github_avm_app_id                               = var.github_avm_app_id
-  labels                                          = local.labels
-  arm_client_id                                   = var.repository_creation_mode_enabled ? "" : module.azure[0].client_id
-  arm_tenant_id                                   = var.repository_creation_mode_enabled ? "" : module.azure[0].tenant_id
-  test_subscription_ids                           = var.repository_creation_mode_enabled ? [] : var.test_subscription_ids
-  module_id                                       = var.module_id
-  module_name                                     = var.module_name
-  copilot_agent_firewall_allow_list               = var.github_copilot_agent_firewall_allow_list
-  copilot_agent_firewall_allow_list_variable_name = var.github_copilot_agent_firewall_allow_list_variable_name
+  repository_creation_mode_enabled                    = var.repository_creation_mode_enabled
+  github_repository_owner                             = var.github_repository_owner
+  github_repository_name                              = var.github_repository_name
+  github_repository_environment_name                  = var.github_repository_environment_name
+  github_repository_test_no_approval_environment_name = var.github_repository_test_no_approval_environment_name
+  github_repository_no_approval_environment_name      = var.github_repository_no_approval_environment_name
+  github_repository_copilot_environment_name          = var.github_repository_copilot_environment_name
+  is_protected_repo                                   = var.is_protected_repo
+  bypass_ruleset_for_approval_enabled                 = true
+  github_teams                                        = var.github_teams
+  github_avm_app_id                                   = var.github_avm_app_id
+  labels                                              = local.labels
+  arm_client_id                                       = var.repository_creation_mode_enabled ? "" : module.azure[0].client_id
+  arm_tenant_id                                       = var.repository_creation_mode_enabled ? "" : module.azure[0].tenant_id
+  test_subscription_ids                               = var.repository_creation_mode_enabled ? [] : var.test_subscription_ids
+  module_id                                           = var.module_id
+  module_name                                         = var.module_name
+  copilot_agent_firewall_allow_list                   = var.github_copilot_agent_firewall_allow_list
+  copilot_agent_firewall_allow_list_variable_name     = var.github_copilot_agent_firewall_allow_list_variable_name
 }
 
 import {

--- a/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
@@ -30,9 +30,9 @@ resource "github_actions_environment_secret" "client_id" {
 }
 
 resource "github_repository_environment" "test_no_approval" {
-  count               = var.repository_creation_mode_enabled ? 0 : 1
-  environment         = var.github_repository_test_no_approval_environment_name
-  repository          = github_repository.this.name
+  count       = var.repository_creation_mode_enabled ? 0 : 1
+  environment = var.github_repository_test_no_approval_environment_name
+  repository  = github_repository.this.name
 }
 
 resource "github_actions_environment_secret" "test_subscription_ids" {


### PR DESCRIPTION
Passes `github_repository_test_no_approval_environment_name` from the root `repository_sync` module into the `github` submodule, and reformats the `github_repository_environment.test_no_approval` resource.