### PR TITLE
chore: fix TEST_SUBSCRIPTION_IDS env var casing and rename step

### DIFF
--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -29,10 +29,10 @@ jobs:
       subscriptionName: ${{ steps.subscriptions.outputs.subscriptionName }}
       subscriptionsJson: ${{ steps.subscriptions.outputs.subscriptionsJson }}
     steps:
-      - name: Get Randomised Subscriptions
+      - name: Get Randomized Subscriptions
         id: subscriptions
         run: |
-          $subscriptions = $env:TEST_SUBSCRIPTION_IDs | ConvertFrom-Json
+          $subscriptions = $env:TEST_SUBSCRIPTION_IDS | ConvertFrom-Json
           $subscriptions = $subscriptions | Get-Random -Shuffle
           $subscriptionsJson = ConvertTo-Json $subscriptions -Compress
           Write-Output "subscriptionsJson=$($subscriptionsJson)" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Corrects the casing of `TEST_SUBSCRIPTION_IDS` when reading from `env:` and renames the step to `Get Randomized Subscriptions`.