### PR TITLE
refactor(ci): split test environment into pr-check and examples-test

### DIFF
--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -1,5 +1,5 @@
 ---
-name: managed pr check and test examples
+name: Managed PR Check and Test Examples
 
 on:
   workflow_call:
@@ -21,15 +21,16 @@ env:
 
 jobs:
   subscriptions:
+    name: Select Randomized Test Subscriptions
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    environment: test-no-approval
+    environment: no-approval
     outputs:
       subscriptionId: ${{ steps.subscriptions.outputs.subscriptionId }}
       subscriptionName: ${{ steps.subscriptions.outputs.subscriptionName }}
       subscriptionsJson: ${{ steps.subscriptions.outputs.subscriptionsJson }}
     steps:
-      - name: Get Randomized Subscriptions
+      - name: Shuffle and select test subscriptions
         id: subscriptions
         run: |
           $subscriptions = $env:TEST_SUBSCRIPTION_IDS | ConvertFrom-Json
@@ -48,12 +49,13 @@ jobs:
         shell: pwsh
 
   pr-check:
+    name: PR Check (Lint, Format, Validate)
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    environment: test
+    environment: pr-check
     needs: subscriptions
     steps:
-      - name: Free up disk space
+      - name: Free up runner disk space
         run: |
           sudo rm -fr /opt/hostedtoolcache
           df -h
@@ -61,9 +63,10 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - name: pr-check
+      - name: Run AVM PR Check
         run: |
           set -e
 
@@ -86,11 +89,11 @@ jobs:
           ./avm pr-check
 
   unit-test:
-    name: Unit Test Run
+    name: Terraform Unit Tests
     runs-on: ubuntu-latest
-    environment: empty-no-approval
+    environment: no-approval
     steps:
-      - name: Free up disk space
+      - name: Free up runner disk space
         run: |
           sudo rm -fr /opt/hostedtoolcache
           df -h
@@ -98,9 +101,10 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - name: Unit Test Run
+      - name: Run Terraform unit tests
         run: |
           set -e
 
@@ -115,13 +119,13 @@ jobs:
           ./avm tf-test-unit
 
   integration-test:
+    name: Terraform Integration Tests
     if: github.event.pull_request.head.repo.fork == false
-    name: Integration Test Run
     runs-on: ubuntu-latest
-    environment: test
+    environment: pr-check
     needs: subscriptions
     steps:
-      - name: Free up disk space
+      - name: Free up runner disk space
         run: |
           sudo rm -fr /opt/hostedtoolcache
           df -h
@@ -129,9 +133,10 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - name: Integration Test Run
+      - name: Run Terraform integration tests
         run: |
           set -e
 
@@ -154,15 +159,17 @@ jobs:
           ./avm tf-test-integration
 
   getexamples:
+    name: Discover Examples
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    environment: test
+    environment: no-approval
     needs: subscriptions
     outputs:
       examples: ${{ steps.getexamples.outputs.examples }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - name: get examples
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Build example matrix and assign subscriptions
         id: getexamples
         run: |
           $examples = Get-ChildItem -Directory
@@ -193,13 +200,15 @@ jobs:
           subscriptionsJson: ${{ needs.subscriptions.outputs.subscriptionsJson }}
 
   checksetup:
+    name: Check for Global Setup Script
     runs-on: ubuntu-latest
-    environment: empty-no-approval
+    environment: no-approval
     outputs:
       setup_exists: ${{ steps.check-setup.outputs.setup_exists }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - name: Check if setup.sh exists
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Check if examples/setup.sh exists
         id: check-setup
         run: |
           if [ -f examples/setup.sh ]; then
@@ -210,12 +219,14 @@ jobs:
         shell: bash
 
   globalsetup:
+    name: Run Global Setup
     if: needs.checksetup.outputs.setup_exists == 'true' && github.event.repository.name != 'terraform-azurerm-avm-template' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    environment: test
+    environment: examples-test
     needs: [ checksetup, subscriptions ]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Run global setup script
         run: |
@@ -238,14 +249,11 @@ jobs:
         shell: bash
 
   testexamples:
+    name: Test Example - ${{ matrix.name }}
     if: always() && !failure() && !cancelled() && github.event.repository.name != 'terraform-azurerm-avm-template' && github.event.pull_request.head.repo.fork == false
-    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: [getexamples, checksetup, globalsetup]
-    environment: test
-    env:
-      TF_IN_AUTOMATION: 1
-      TF_VAR_enable_telemetry: false
+    environment: examples-test
     strategy:
       matrix:
         include: ${{ fromJson(needs.getexamples.outputs.examples) }}
@@ -253,9 +261,10 @@ jobs:
     steps:
       - name: Set up Docker
         uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - name: Test example
+      - name: Deploy and validate example
         shell: bash
         env:
           AVM_EXAMPLE: ${{ matrix.name }}
@@ -283,15 +292,17 @@ jobs:
           ./avm test-examples
 
   checkteardown:
+    name: Check for Global Teardown Script
     runs-on: ubuntu-latest
     if: always() && github.event.repository.name != 'terraform-azurerm-avm-template' && github.event.pull_request.head.repo.fork == false
     needs: testexamples
-    environment: empty-no-approval
+    environment: no-approval
     outputs:
       teardown_exists: ${{ steps.check-teardown.outputs.teardown_exists }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - name: Check if teardown.sh exists
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Check if examples/teardown.sh exists
         id: check-teardown
         run: |
           if [ -f examples/teardown.sh ]; then
@@ -302,14 +313,16 @@ jobs:
         shell: bash
 
   globalteardown:
+    name: Run Global Teardown
     if: always() && needs.checkteardown.outputs.teardown_exists == 'true' && github.event.repository.name != 'terraform-azurerm-avm-template' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    environment: test
+    environment: examples-test
     needs: [checkteardown, subscriptions]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - name: Run teardown script
+      - name: Run global teardown script
         run: |
           set -e
 
@@ -329,13 +342,3 @@ jobs:
           ./avm global-teardown
         id: global-teardown
         shell: bash
-
-  # This job is only run when all the previous jobs are successful.
-  # We can use it for PR validation to ensure all examples have completed.
-  testexamplescomplete:
-    if: always() && !failure() && !cancelled() && github.event.repository.name != 'terraform-azurerm-avm-template' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
-    environment: empty-no-approval
-    needs: testexamples
-    steps:
-      - run: echo "All tests passed"

--- a/tf-repo-mgmt/repository_sync/main.tf
+++ b/tf-repo-mgmt/repository_sync/main.tf
@@ -2,40 +2,43 @@ module "azure" {
   source = "./modules/azure"
   count  = var.repository_creation_mode_enabled ? 0 : 1
 
-  management_group_id                = var.management_group_id
-  github_repository_owner            = var.github_repository_owner
-  github_repository_name             = var.github_repository_name
-  github_repository_environment_name = var.github_repository_environment_name
-  identity_resource_group_name       = var.identity_resource_group_name
-  location                           = var.location
-  github_job_workflow_ref            = var.github_job_workflow_ref
-  github_organization_id             = module.github.organization_id
-  github_repository_id               = module.github.repository_id
-  is_protected_repo                  = var.is_protected_repo
+  management_group_id          = var.management_group_id
+  github_repository_owner      = var.github_repository_owner
+  github_repository_name       = var.github_repository_name
+  github_repository_environment_names = [
+    var.github_repository_pr_check_environment_name,
+    var.github_repository_examples_test_environment_name,
+  ]
+  identity_resource_group_name = var.identity_resource_group_name
+  location                     = var.location
+  github_job_workflow_ref      = var.github_job_workflow_ref
+  github_organization_id       = module.github.organization_id
+  github_repository_id         = module.github.repository_id
+  is_protected_repo            = var.is_protected_repo
 }
 
 module "github" {
   source = "./modules/github"
 
-  repository_creation_mode_enabled                    = var.repository_creation_mode_enabled
-  github_repository_owner                             = var.github_repository_owner
-  github_repository_name                              = var.github_repository_name
-  github_repository_environment_name                  = var.github_repository_environment_name
-  github_repository_test_no_approval_environment_name = var.github_repository_test_no_approval_environment_name
-  github_repository_no_approval_environment_name      = var.github_repository_no_approval_environment_name
-  github_repository_copilot_environment_name          = var.github_repository_copilot_environment_name
-  is_protected_repo                                   = var.is_protected_repo
-  bypass_ruleset_for_approval_enabled                 = true
-  github_teams                                        = var.github_teams
-  github_avm_app_id                                   = var.github_avm_app_id
-  labels                                              = local.labels
-  arm_client_id                                       = var.repository_creation_mode_enabled ? "" : module.azure[0].client_id
-  arm_tenant_id                                       = var.repository_creation_mode_enabled ? "" : module.azure[0].tenant_id
-  test_subscription_ids                               = var.repository_creation_mode_enabled ? [] : var.test_subscription_ids
-  module_id                                           = var.module_id
-  module_name                                         = var.module_name
-  copilot_agent_firewall_allow_list                   = var.github_copilot_agent_firewall_allow_list
-  copilot_agent_firewall_allow_list_variable_name     = var.github_copilot_agent_firewall_allow_list_variable_name
+  repository_creation_mode_enabled                 = var.repository_creation_mode_enabled
+  github_repository_owner                          = var.github_repository_owner
+  github_repository_name                           = var.github_repository_name
+  github_repository_pr_check_environment_name      = var.github_repository_pr_check_environment_name
+  github_repository_examples_test_environment_name = var.github_repository_examples_test_environment_name
+  github_repository_no_approval_environment_name   = var.github_repository_no_approval_environment_name
+  github_repository_copilot_environment_name       = var.github_repository_copilot_environment_name
+  is_protected_repo                                = var.is_protected_repo
+  bypass_ruleset_for_approval_enabled              = true
+  github_teams                                     = var.github_teams
+  github_avm_app_id                                = var.github_avm_app_id
+  labels                                           = local.labels
+  arm_client_id                                    = var.repository_creation_mode_enabled ? "" : module.azure[0].client_id
+  arm_tenant_id                                    = var.repository_creation_mode_enabled ? "" : module.azure[0].tenant_id
+  test_subscription_ids                            = var.repository_creation_mode_enabled ? [] : var.test_subscription_ids
+  module_id                                        = var.module_id
+  module_name                                      = var.module_name
+  copilot_agent_firewall_allow_list                = var.github_copilot_agent_firewall_allow_list
+  copilot_agent_firewall_allow_list_variable_name  = var.github_copilot_agent_firewall_allow_list_variable_name
 }
 
 import {

--- a/tf-repo-mgmt/repository_sync/modules/azure/main.tf
+++ b/tf-repo-mgmt/repository_sync/modules/azure/main.tf
@@ -14,15 +14,17 @@ resource "azapi_resource" "identity" {
 }
 
 resource "azapi_resource" "identity_federated_credentials" {
+  for_each = var.github_repository_environment_names
+
   type      = "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-07-31-preview"
-  name      = local.owner_repo_name
+  name      = "${local.owner_repo_name}-${each.value}"
   parent_id = azapi_resource.identity.id
-  locks     = [azapi_resource.identity.id] # not needed but added if we configure more than one environment
+  locks     = [azapi_resource.identity.id]
   body = {
     properties = {
       audiences = ["api://AzureADTokenExchange"]
       issuer    = "https://token.actions.githubusercontent.com"
-      subject   = "repository_owner_id:${var.github_organization_id}:repository_id:${var.github_repository_id}:environment:${var.github_repository_environment_name}:job_workflow_ref:${var.github_job_workflow_ref}"
+      subject   = "repository_owner_id:${var.github_organization_id}:repository_id:${var.github_repository_id}:environment:${each.value}:job_workflow_ref:${var.github_job_workflow_ref}"
     }
   }
 }

--- a/tf-repo-mgmt/repository_sync/modules/azure/variables.tf
+++ b/tf-repo-mgmt/repository_sync/modules/azure/variables.tf
@@ -18,9 +18,9 @@ variable "github_repository_name" {
   description = "Name of the GitHub repository."
 }
 
-variable "github_repository_environment_name" {
-  type        = string
-  description = "Name of the environment used to store secrets for the test environment."
+variable "github_repository_environment_names" {
+  type        = set(string)
+  description = "Names of the GitHub environments to create federated identity credentials for. The OIDC subject claim includes the environment name, so one credential is created per environment."
 }
 
 variable "location" {

--- a/tf-repo-mgmt/repository_sync/modules/github/github.actions_secrets.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/github.actions_secrets.tf
@@ -1,0 +1,23 @@
+# Shared Azure auth values are stored at repository scope so they can be
+# consumed by any environment (and any new environment added in future)
+# without duplicating per-environment secrets.
+resource "github_actions_secret" "arm_tenant_id" {
+  count           = var.repository_creation_mode_enabled ? 0 : 1
+  repository      = github_repository.this.name
+  secret_name     = "ARM_TENANT_ID"
+  plaintext_value = var.arm_tenant_id
+}
+
+resource "github_actions_secret" "arm_client_id" {
+  count           = var.repository_creation_mode_enabled ? 0 : 1
+  repository      = github_repository.this.name
+  secret_name     = "ARM_CLIENT_ID"
+  plaintext_value = var.arm_client_id
+}
+
+resource "github_actions_secret" "test_subscription_ids" {
+  count           = var.repository_creation_mode_enabled ? 0 : 1
+  repository      = github_repository.this.name
+  secret_name     = "TEST_SUBSCRIPTION_IDS"
+  plaintext_value = jsonencode(var.test_subscription_ids)
+}

--- a/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
@@ -1,52 +1,57 @@
 locals {
-  environment_approval_teams = { for k, v in var.github_teams : k => data.github_team.this[k].id if v.environment_approval }
+  environment_approval_team_ids = [for k, v in var.github_teams : data.github_team.this[k].id if v.environment_approval]
+
+  # Approval-gated environments. Map key -> environment name.
+  approval_environments = var.repository_creation_mode_enabled ? {} : {
+    pr_check      = var.github_repository_pr_check_environment_name
+    examples_test = var.github_repository_examples_test_environment_name
+  }
 }
 
-resource "github_repository_environment" "this" {
-  count               = var.repository_creation_mode_enabled ? 0 : 1
-  environment         = var.github_repository_environment_name
+# Approval-gated environments (PR check and example tests).
+# Both share the same reviewer teams and the same Azure identity (federated
+# credentials are created per-environment in the azure module so the OIDC
+# subject claim matches).
+resource "github_repository_environment" "approval" {
+  for_each = local.approval_environments
+
+  environment         = each.value
   repository          = github_repository.this.name
   can_admins_bypass   = true
   prevent_self_review = false
   reviewers {
-    teams = values(local.environment_approval_teams)
+    teams = local.environment_approval_team_ids
   }
 }
 
-resource "github_actions_environment_secret" "tenant_id" {
+# This environment is used for jobs that do not require approval (or auth).
+# Due to the OIDC subject claim refs mandating that environment is included,
+# all jobs must be run in an environment whether they need authentication or not.
+resource "github_repository_environment" "no_approval" {
+  environment = var.github_repository_no_approval_environment_name
+  repository  = github_repository.this.name
+}
+
+# Shared Azure auth values are stored at repository scope so they can be
+# consumed by any environment (and any new environment added in future)
+# without duplicating per-environment secrets.
+resource "github_actions_secret" "arm_tenant_id" {
   count           = var.repository_creation_mode_enabled ? 0 : 1
   repository      = github_repository.this.name
-  environment     = github_repository_environment.this[0].environment
   secret_name     = "ARM_TENANT_ID"
   plaintext_value = var.arm_tenant_id
 }
 
-resource "github_actions_environment_secret" "client_id" {
+resource "github_actions_secret" "arm_client_id" {
   count           = var.repository_creation_mode_enabled ? 0 : 1
   repository      = github_repository.this.name
-  environment     = github_repository_environment.this[0].environment
   secret_name     = "ARM_CLIENT_ID"
   plaintext_value = var.arm_client_id
 }
 
-resource "github_repository_environment" "test_no_approval" {
-  count       = var.repository_creation_mode_enabled ? 0 : 1
-  environment = var.github_repository_test_no_approval_environment_name
-  repository  = github_repository.this.name
-}
-
-resource "github_actions_environment_secret" "test_subscription_ids" {
+resource "github_actions_secret" "test_subscription_ids" {
   count           = var.repository_creation_mode_enabled ? 0 : 1
   repository      = github_repository.this.name
-  environment     = github_repository_environment.test_no_approval[0].environment
   secret_name     = "TEST_SUBSCRIPTION_IDS"
   plaintext_value = jsonencode(var.test_subscription_ids)
-}
-
-# This environment is used for jobs that do not require authentication.
-# Due to the OIDC subject claim refs mandating that environment is included,
-# all jobs must be run in an environment whether they need authentication or not.
-resource "github_repository_environment" "dummy_no_approval" {
-  environment = var.github_repository_no_approval_environment_name
-  repository  = github_repository.this.name
 }

--- a/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
@@ -31,27 +31,3 @@ resource "github_repository_environment" "no_approval" {
   environment = var.github_repository_no_approval_environment_name
   repository  = github_repository.this.name
 }
-
-# Shared Azure auth values are stored at repository scope so they can be
-# consumed by any environment (and any new environment added in future)
-# without duplicating per-environment secrets.
-resource "github_actions_secret" "arm_tenant_id" {
-  count           = var.repository_creation_mode_enabled ? 0 : 1
-  repository      = github_repository.this.name
-  secret_name     = "ARM_TENANT_ID"
-  plaintext_value = var.arm_tenant_id
-}
-
-resource "github_actions_secret" "arm_client_id" {
-  count           = var.repository_creation_mode_enabled ? 0 : 1
-  repository      = github_repository.this.name
-  secret_name     = "ARM_CLIENT_ID"
-  plaintext_value = var.arm_client_id
-}
-
-resource "github_actions_secret" "test_subscription_ids" {
-  count           = var.repository_creation_mode_enabled ? 0 : 1
-  repository      = github_repository.this.name
-  secret_name     = "TEST_SUBSCRIPTION_IDS"
-  plaintext_value = jsonencode(var.test_subscription_ids)
-}

--- a/tf-repo-mgmt/repository_sync/modules/github/variables.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/variables.tf
@@ -41,19 +41,19 @@ variable "module_name" {
   description = "Description of the AVM (e.g. Azure Landing Zones Management Resources)"
 }
 
-variable "github_repository_environment_name" {
+variable "github_repository_pr_check_environment_name" {
   type        = string
-  description = "Name of the environment used to store secrets for the test environment."
+  description = "Name of the approval-gated environment used by the PR check and integration test jobs."
 }
 
-variable "github_repository_test_no_approval_environment_name" {
+variable "github_repository_examples_test_environment_name" {
   type        = string
-  description = "Name of the environment used to store secrets for the test environment without approval."
+  description = "Name of the approval-gated environment used by the example test jobs."
 }
 
 variable "github_repository_no_approval_environment_name" {
   type        = string
-  description = "Name of the environment used as a dummy no approval environment."
+  description = "Name of the environment used by jobs that do not require approval."
 }
 
 variable "github_repository_copilot_environment_name" {

--- a/tf-repo-mgmt/repository_sync/variables.tf
+++ b/tf-repo-mgmt/repository_sync/variables.tf
@@ -43,22 +43,22 @@ variable "module_name" {
   description = "Description of the AVM (e.g. Azure Landing Zones Management Resources)"
 }
 
-variable "github_repository_environment_name" {
+variable "github_repository_pr_check_environment_name" {
   type        = string
-  description = "Name of the environment used to store secrets for the test environment."
-  default     = "test"
+  description = "Name of the approval-gated environment used by the PR check and integration test jobs."
+  default     = "pr-check"
 }
 
-variable "github_repository_test_no_approval_environment_name" {
+variable "github_repository_examples_test_environment_name" {
   type        = string
-  description = "Name of the environment used to store secrets for the test environment with no approval."
-  default     = "test-no-approval"
+  description = "Name of the approval-gated environment used by the example test jobs."
+  default     = "examples-test"
 }
 
 variable "github_repository_no_approval_environment_name" {
   type        = string
-  description = "Name of the environment used as a dummy no approval environment."
-  default     = "empty-no-approval"
+  description = "Name of the environment used by jobs that do not require approval (still required to satisfy the OIDC subject claim)."
+  default     = "no-approval"
 }
 
 variable "github_repository_copilot_environment_name" {


### PR DESCRIPTION
## Summary

Refactors the GitHub environments used by the managed PR check workflow so each environment has a single, clear purpose, and cleans up the workflow itself.

## Environment changes

Splits the previous single `test` environment (used by both PR checks and example tests) into two purpose-named, approval-gated environments. Also collapses `empty-no-approval` and `test-no-approval` into a single `no-approval` environment.

| Old | New | Used by |
|---|---|---|
| `test` | `pr-check` | `pr-check`, `integration-test` |
| `test` | `examples-test` | `globalsetup`, `testexamples`, `globalteardown` |
| `empty-no-approval` / `test-no-approval` | `no-approval` | `subscriptions`, `unit-test`, `getexamples`, `checksetup`, `checkteardown` |
| `copilot` | `copilot` (unchanged) | Copilot agent |

## Terraform changes (`tf-repo-mgmt/repository_sync`)

- Renamed environment-name variables to `github_repository_pr_check_environment_name`, `github_repository_examples_test_environment_name`, `github_repository_no_approval_environment_name`.
- `github_repository_environment.approval` now uses `for_each` over the two approval-gated environments — adding a third in future is a one-line change.
- Shared Azure auth secrets (`ARM_TENANT_ID`, `ARM_CLIENT_ID`, `TEST_SUBSCRIPTION_IDS`) moved from per-environment scope to **repository scope** (`github_actions_secret`) — no more duplicating the same values across environments.
- Federated identity credentials in the `azure` module now use `for_each` over `github_repository_environment_names` (set), so the OIDC subject claim matches whichever environment a job runs in. One credential is created per approval-gated environment.

## Workflow improvements (`.github/workflows/managed-pr-check.yml`)

- Title-cased the workflow name: `Managed PR Check and Test Examples`.
- Every job has a descriptive `name:` (e.g. `PR Check (Lint, Format, Validate)`, `Terraform Integration Tests`, `Test Example - <matrix>`).
- Every step has a meaningful name (no more anonymous `uses: actions/checkout`; `pr-check` step renamed to `Run AVM PR Check`, etc.).
- Removed the redundant `env:` block on `testexamples` (values are inherited from workflow scope).
- Removed the dead `testexamplescomplete` job — it had no consumers, no downstream `needs:`, and its `if: always() && !failure() && !cancelled()` condition would *skip* (not fail) when example tests failed, making it useless as a fan-in gate.

## Migration / apply notes

When `repository_sync` is applied against existing managed repos:

1. The `test`, `test-no-approval`, and `empty-no-approval` GitHub environments will be **destroyed** and the new ones created. Any pending approvals on `test` will be lost.
2. The single federated identity credential `${owner}-${repo}` will be replaced by `${owner}-${repo}-pr-check` and `${owner}-${repo}-examples-test`. Add `moved` blocks if you want to preserve the existing one as the `pr-check` cred — otherwise expect destroy/create churn.
3. `ARM_TENANT_ID` / `ARM_CLIENT_ID` / `TEST_SUBSCRIPTION_IDS` will move from environment-scope to repo-scope. The workflow already references them via `secrets.<NAME>`, which transparently resolves repo secrets too — no further workflow edits needed.
4. Any branch-protection / required-status-check settings configured manually in consumer repo UIs that referenced the old job names (`test` / `empty-no-approval` envs, or the `testexamplescomplete` check) will need to be updated to the new names.
