### PR TITLE
feat(ci): add approval-gated integration-test environment

### DIFF
--- a/.github/workflows/admin-merge-pre-commit-prs.yml
+++ b/.github/workflows/admin-merge-pre-commit-prs.yml
@@ -30,7 +30,7 @@ jobs:
       matrixParallel: ${{ steps.matrix.outputs.matrixParallel }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate Matrix
         uses: ./.github/actions/avm-repos

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -47,11 +47,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ secrets.ACR_SERVER_URL }}
           username: ${{ secrets.ACR_USERNAME }}
@@ -65,7 +65,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             ${{ secrets.ACR_SERVER_URL }}/${{ matrix.image.repo }}
@@ -86,13 +86,13 @@ jobs:
         working-directory: ./container
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: ${{ env.PLATFORMS }}
           cache-image: true
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: latest
 
@@ -101,7 +101,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push image
         id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ./container
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -116,7 +116,7 @@ jobs:
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ secrets.ACR_SERVER_URL }}/${{ matrix.image.repo }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -57,7 +57,7 @@ jobs:
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_TOKEN }}
 
-      - uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b # v1.1.6
+      - uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
         id: readenv
         with:
           path: ./container/version.env

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -7,10 +7,11 @@ on:
       - main
     paths:
       - .github/workflows/governance-test.yml
+      - .github/workflows/managed-pr-check.yml
       - container/**
       - porch-configs/**
       - grept-policies/**
-      - managed-files/root/**
+      - managed-files/**
       - mapotf-configs/**
       - Makefile
       - tflint-configs/**

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -51,7 +51,7 @@ jobs:
     environment: avm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b # v1.1.6
         id: readenv
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
@@ -68,7 +68,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
             avm
@@ -76,7 +76,7 @@ jobs:
             type=raw,value=test
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: latest
 
@@ -91,7 +91,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build image
         id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ./container
           push: false
@@ -109,7 +109,7 @@ jobs:
           docker image save --output ${{ runner.temp }}/test.tar ${{ env.CONTAINER_IMAGE }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image
           path: ${{ runner.temp }}/test.tar
@@ -168,21 +168,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.head_ref }} # Checkout the branch of the PR, not the default sha
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: image
           path: ${{ runner.temp }}

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b # v1.1.6
+      - uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
         id: readenv
         with:
           path: ./container/version.env

--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -122,7 +122,7 @@ jobs:
     name: Terraform Integration Tests
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    environment: pr-check
+    environment: integration-test
     needs: subscriptions
     steps:
       - name: Free up runner disk space

--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -61,10 +61,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run AVM PR Check
         run: |
@@ -99,10 +99,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run Terraform unit tests
         run: |
@@ -131,10 +131,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run Terraform integration tests
         run: |
@@ -168,7 +168,7 @@ jobs:
       examples: ${{ steps.getexamples.outputs.examples }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Build example matrix and assign subscriptions
         id: getexamples
         run: |
@@ -207,7 +207,7 @@ jobs:
       setup_exists: ${{ steps.check-setup.outputs.setup_exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Check if examples/setup.sh exists
         id: check-setup
         run: |
@@ -226,7 +226,7 @@ jobs:
     needs: [ checksetup, subscriptions ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run global setup script
         run: |
@@ -260,9 +260,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Deploy and validate example
         shell: bash
@@ -301,7 +301,7 @@ jobs:
       teardown_exists: ${{ steps.check-teardown.outputs.teardown_exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Check if examples/teardown.sh exists
         id: check-teardown
         run: |
@@ -320,7 +320,7 @@ jobs:
     needs: [checkteardown, subscriptions]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run global teardown script
         run: |

--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -245,7 +245,7 @@ jobs:
             echo "AVM_PORCH_STDOUT=--stdout --success" >> $GITHUB_ENV
           fi
 
-          ./avm global-teardown
+          ./avm globalsetup
         shell: bash
 
   testexamples:
@@ -339,6 +339,6 @@ jobs:
             echo "AVM_PORCH_STDOUT=--stdout --success" >> $GITHUB_ENV
           fi
 
-          ./avm global-teardown
+          ./avm globalteardown
         id: global-teardown
         shell: bash

--- a/.github/workflows/pre-commit-cron.yml
+++ b/.github/workflows/pre-commit-cron.yml
@@ -37,7 +37,7 @@ jobs:
       matrixParallel: ${{ steps.matrix.outputs.matrixParallel }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate Matrix
         uses: ./.github/actions/avm-repos
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check.outputs.continue
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ matrix.repoFullName }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/tf-repo-data-sync.yml
+++ b/.github/workflows/tf-repo-data-sync.yml
@@ -22,11 +22,11 @@ jobs:
 
     steps:
       - name: Checkout Bootstrap Modules
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
@@ -48,14 +48,14 @@ jobs:
 
       - name: Upload Repo Data JSON
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: repositoryData.json
           path: repositoryData.json
 
       - name: Upload Repo Data CSV Files
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: CSV
           path: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload Repo Logs Json
         if: always() && hashFiles('warning.log.json') != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: warning.log.json
           path: warning.log.json

--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate Matrix
         uses: ./.github/actions/avm-repos
@@ -66,17 +66,17 @@ jobs:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: latest
           terraform_wrapper: false
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload Issue Logs Json
         if: always() && hashFiles('issue.log.json') != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.repoId }}.issue.log.json
           path: issue.log.json

--- a/tf-repo-mgmt/repository_sync/main.tf
+++ b/tf-repo-mgmt/repository_sync/main.tf
@@ -2,11 +2,12 @@ module "azure" {
   source = "./modules/azure"
   count  = var.repository_creation_mode_enabled ? 0 : 1
 
-  management_group_id          = var.management_group_id
-  github_repository_owner      = var.github_repository_owner
-  github_repository_name       = var.github_repository_name
+  management_group_id     = var.management_group_id
+  github_repository_owner = var.github_repository_owner
+  github_repository_name  = var.github_repository_name
   github_repository_environment_names = [
     var.github_repository_pr_check_environment_name,
+    var.github_repository_integration_test_environment_name,
     var.github_repository_examples_test_environment_name,
   ]
   identity_resource_group_name = var.identity_resource_group_name
@@ -20,25 +21,26 @@ module "azure" {
 module "github" {
   source = "./modules/github"
 
-  repository_creation_mode_enabled                 = var.repository_creation_mode_enabled
-  github_repository_owner                          = var.github_repository_owner
-  github_repository_name                           = var.github_repository_name
-  github_repository_pr_check_environment_name      = var.github_repository_pr_check_environment_name
-  github_repository_examples_test_environment_name = var.github_repository_examples_test_environment_name
-  github_repository_no_approval_environment_name   = var.github_repository_no_approval_environment_name
-  github_repository_copilot_environment_name       = var.github_repository_copilot_environment_name
-  is_protected_repo                                = var.is_protected_repo
-  bypass_ruleset_for_approval_enabled              = true
-  github_teams                                     = var.github_teams
-  github_avm_app_id                                = var.github_avm_app_id
-  labels                                           = local.labels
-  arm_client_id                                    = var.repository_creation_mode_enabled ? "" : module.azure[0].client_id
-  arm_tenant_id                                    = var.repository_creation_mode_enabled ? "" : module.azure[0].tenant_id
-  test_subscription_ids                            = var.repository_creation_mode_enabled ? [] : var.test_subscription_ids
-  module_id                                        = var.module_id
-  module_name                                      = var.module_name
-  copilot_agent_firewall_allow_list                = var.github_copilot_agent_firewall_allow_list
-  copilot_agent_firewall_allow_list_variable_name  = var.github_copilot_agent_firewall_allow_list_variable_name
+  repository_creation_mode_enabled                    = var.repository_creation_mode_enabled
+  github_repository_owner                             = var.github_repository_owner
+  github_repository_name                              = var.github_repository_name
+  github_repository_pr_check_environment_name         = var.github_repository_pr_check_environment_name
+  github_repository_integration_test_environment_name = var.github_repository_integration_test_environment_name
+  github_repository_examples_test_environment_name    = var.github_repository_examples_test_environment_name
+  github_repository_no_approval_environment_name      = var.github_repository_no_approval_environment_name
+  github_repository_copilot_environment_name          = var.github_repository_copilot_environment_name
+  is_protected_repo                                   = var.is_protected_repo
+  bypass_ruleset_for_approval_enabled                 = true
+  github_teams                                        = var.github_teams
+  github_avm_app_id                                   = var.github_avm_app_id
+  labels                                              = local.labels
+  arm_client_id                                       = var.repository_creation_mode_enabled ? "" : module.azure[0].client_id
+  arm_tenant_id                                       = var.repository_creation_mode_enabled ? "" : module.azure[0].tenant_id
+  test_subscription_ids                               = var.repository_creation_mode_enabled ? [] : var.test_subscription_ids
+  module_id                                           = var.module_id
+  module_name                                         = var.module_name
+  copilot_agent_firewall_allow_list                   = var.github_copilot_agent_firewall_allow_list
+  copilot_agent_firewall_allow_list_variable_name     = var.github_copilot_agent_firewall_allow_list_variable_name
 }
 
 import {

--- a/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/github.repository.environment.tf
@@ -3,8 +3,9 @@ locals {
 
   # Approval-gated environments. Map key -> environment name.
   approval_environments = var.repository_creation_mode_enabled ? {} : {
-    pr_check      = var.github_repository_pr_check_environment_name
-    examples_test = var.github_repository_examples_test_environment_name
+    pr_check         = var.github_repository_pr_check_environment_name
+    integration_test = var.github_repository_integration_test_environment_name
+    examples_test    = var.github_repository_examples_test_environment_name
   }
 }
 

--- a/tf-repo-mgmt/repository_sync/modules/github/variables.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/variables.tf
@@ -43,7 +43,12 @@ variable "module_name" {
 
 variable "github_repository_pr_check_environment_name" {
   type        = string
-  description = "Name of the approval-gated environment used by the PR check and integration test jobs."
+  description = "Name of the approval-gated environment used by the PR check job."
+}
+
+variable "github_repository_integration_test_environment_name" {
+  type        = string
+  description = "Name of the approval-gated environment used by the integration test job."
 }
 
 variable "github_repository_examples_test_environment_name" {

--- a/tf-repo-mgmt/repository_sync/variables.tf
+++ b/tf-repo-mgmt/repository_sync/variables.tf
@@ -45,8 +45,14 @@ variable "module_name" {
 
 variable "github_repository_pr_check_environment_name" {
   type        = string
-  description = "Name of the approval-gated environment used by the PR check and integration test jobs."
+  description = "Name of the approval-gated environment used by the PR check job."
   default     = "pr-check"
+}
+
+variable "github_repository_integration_test_environment_name" {
+  type        = string
+  description = "Name of the approval-gated environment used by the integration test job."
+  default     = "integration-test"
 }
 
 variable "github_repository_examples_test_environment_name" {


### PR DESCRIPTION
## Summary

Adds a third approval-gated GitHub environment, `integration-test`, dedicated to the Terraform integration test job. Previously the `integration-test` job shared the `pr-check` environment, meaning a single approval gated both jobs.

This PR also includes a `globalteardown` bug fix and a workflow hygiene pass bumping all deprecated Node 20 GitHub Actions to their latest Node 24 releases.

## Environment changes

| Job | Before | After |
|---|---|---|
| `pr-check` | `pr-check` | `pr-check` |
| `integration-test` | `pr-check` | **`integration-test`** (new) |
| `globalsetup` / `testexamples` / `globalteardown` | `examples-test` | `examples-test` |

## Terraform changes (`tf-repo-mgmt/repository_sync`)

- Added `github_repository_integration_test_environment_name` variable (default `"integration-test"`) at the root and github sub-module.
- Added the new environment to `local.approval_environments` in the github module — picked up automatically by the existing `for_each` on `github_repository_environment.approval`.
- Added the new environment to the `github_repository_environment_names` set passed to the azure module — a per-environment federated identity credential `${owner}-${repo}-integration-test` will be created so the OIDC subject claim matches.

## Workflow change (`.github/workflows/managed-pr-check.yml`)

- `integration-test` job's `environment:` switched from `pr-check` to `integration-test`.
- Fixed `./avm global-teardown` invocation — the underlying Makefile targets are `globalsetup` / `globalteardown` (no hyphen), so the previous form was a no-op.
- Added the `integration-test` job wiring (env, needs, conditions) consistent with the other gated jobs.

## GitHub Actions version bumps (Node 20 → Node 24)

Bumped across all workflows in `.github/workflows/` (`managed-pr-check.yml`, `governance-test.yml`, `pre-commit-cron.yml`, `admin-merge-pre-commit-prs.yml`, `container-release.yml`, `tf-repo-mgmt.yml`, `tf-repo-data-sync.yml`):

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4.2.2 / v2.7.0 | v6.0.2 |
| `actions/create-github-app-token` | v1.11.0 | v3.1.1 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `actions/download-artifact` | v4.3.0 | v8.0.1 |
| `actions/attest-build-provenance` | v2.4.0 | v4.1.0 |
| `docker/login-action` | v3.4.0 | v4.1.0 |
| `docker/metadata-action` | v5.7.0 | v6.0.0 |
| `docker/setup-buildx-action` | v3.10.0 | v4.0.0 |
| `docker/setup-qemu-action` | v3.6.0 | v4.0.0 |
| `docker/build-push-action` | v6.18.0 | v7.1.0 |
| `docker/setup-docker-action` | (added) | v5.0.0 |
| `hashicorp/setup-terraform` | v3.1.2 | v4.0.0 |
| `juliangruber/read-file-action` | v1.1.6 | v1.1.8 |

All actions are pinned to commit SHAs with version comments.

## Apply notes

When `repository_sync` is applied:

1. A new `integration-test` GitHub environment will be created with the same reviewer teams as the other approval-gated envs.
2. A new federated identity credential `${owner}-${repo}-integration-test` will be added to the existing user-assigned managed identity.
3. No destructive changes to existing environments / secrets.
