### PR TITLE
chore(ci): bump checkout and setup-docker-action to Node.js 24 versions

### DIFF
--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -61,10 +61,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run AVM PR Check
         run: |
@@ -99,10 +99,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run Terraform unit tests
         run: |
@@ -131,10 +131,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run Terraform integration tests
         run: |
@@ -168,7 +168,7 @@ jobs:
       examples: ${{ steps.getexamples.outputs.examples }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Build example matrix and assign subscriptions
         id: getexamples
         run: |
@@ -207,7 +207,7 @@ jobs:
       setup_exists: ${{ steps.check-setup.outputs.setup_exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Check if examples/setup.sh exists
         id: check-setup
         run: |
@@ -226,7 +226,7 @@ jobs:
     needs: [ checksetup, subscriptions ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run global setup script
         run: |
@@ -260,9 +260,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Set up Docker
-        uses: docker/setup-docker-action@efe9e3891a4f7307e689f2100b33a155b900a608 #v4.5.0
+        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Deploy and validate example
         shell: bash
@@ -301,7 +301,7 @@ jobs:
       teardown_exists: ${{ steps.check-teardown.outputs.teardown_exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Check if examples/teardown.sh exists
         id: check-teardown
         run: |
@@ -320,7 +320,7 @@ jobs:
     needs: [checkteardown, subscriptions]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run global teardown script
         run: |


### PR DESCRIPTION
Bumps the two JavaScript actions in `.github/workflows/managed-pr-check.yml` to releases that run on Node.js 24, addressing the runner deprecation warning:

> Node.js 20 actions are deprecated. … Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v4.2.2` (`11bd7190`) | **`v6.0.2`** (`de0fac2e`) |
| `docker/setup-docker-action` | `v4.5.0` (`efe9e389`) | **`v5.0.0`** (`1a6edb0b`) |

Both pins use the full commit SHA with a version comment, matching the existing convention.

### Notes
- `actions/checkout@v5.0.0+` and `docker/setup-docker-action@v5.0.0` require Actions Runner `v2.327.1` or later, which is satisfied by current GitHub-hosted runners.
- No behavioural changes are expected for the way these actions are used here (default checkout, Docker setup with default config).
- 13 occurrences total updated (9 × checkout, 4 × setup-docker-action).
