### PR TITLE
feat: support AVM_BARE_-prefixed vars and dedupe module-metadata-missing warning

### DIFF
--- a/managed-files/root/avm
+++ b/managed-files/root/avm
@@ -173,6 +173,15 @@ if [ -f "avm.config.json" ]; then
   done
 fi
 
+# Forward AVM_BARE_* environment variables to the container with the prefix stripped
+while IFS='=' read -r bareKey bareValue; do
+  [ -z "$bareKey" ] && continue
+  strippedKey="${bareKey#AVM_BARE_}"
+  export "$strippedKey"="$bareValue"
+  LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $strippedKey "
+  echo "Forwarding AVM bare variable to container as: $strippedKey"
+done < <(env | grep '^AVM_BARE_' || true)
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -199,7 +208,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e TF_IN_AUTOMATION=1 \
     ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
-    --env-file <(env | grep '^AVM_') \
+    --env-file <(env | grep '^AVM_' | grep -v '^AVM_BARE_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \

--- a/managed-files/root/avm.ps1
+++ b/managed-files/root/avm.ps1
@@ -150,9 +150,16 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
-  # Add AVM_ environment variables
-  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" } | ForEach-Object {
+  # Add AVM_ environment variables (excluding AVM_BARE_* which are forwarded with the prefix stripped)
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" -and $_.Name -notlike "AVM_BARE_*" } | ForEach-Object {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
+  }
+
+  # Forward AVM_BARE_* environment variables to the container with the prefix stripped
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_BARE_*" } | ForEach-Object {
+    $strippedName = $_.Name -replace '^AVM_BARE_', ''
+    $dockerArgs += @("-e", "$strippedName=$($_.Value)")
+    Write-Host "Forwarding AVM bare variable to container as: $strippedName"
   }
 
   # Add local environment variables from avm.config.json

--- a/scripts/gha-azure-cred-prep.sh
+++ b/scripts/gha-azure-cred-prep.sh
@@ -15,6 +15,11 @@ for key in "${!secrets[@]}"; do
     lowerKey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
     finalKey=${lowerKey/tf_var_/TF_VAR_}
     export "$finalKey"="${secrets[$key]}"
+    echo "Exported Terraform secret: $finalKey"
+  elif [[ $key = E2E_TEST_* ]]; then
+    finalKey=${key#E2E_TEST_}
+    export "$finalKey"="${secrets[$key]}"
+    echo "Exported E2E test secret: $finalKey"
   fi
 done
 
@@ -23,10 +28,13 @@ for key in "${!variables[@]}"; do
     lowerKey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
     finalKey=${lowerKey/tf_var_/TF_VAR_}
     export "$finalKey"="${variables[$key]}"
+    echo "Exported Terraform variable: $finalKey"
+  elif [[ $key = E2E_TEST_* ]]; then
+    finalKey=${key#E2E_TEST_}
+    export "$finalKey"="${variables[$key]}"
+    echo "Exported E2E test variable: $finalKey"
   fi
 done
-
-echo -e "Custom environment variables:\n$(env | grep '^TF_VAR_')"
 
 # Use override values if provided, otherwise use the default values from the environment
 export ARM_TENANT_ID="${ARM_TENANT_ID_OVERRIDE:-${ARM_TENANT_ID}}"

--- a/scripts/gha-azure-cred-prep.sh
+++ b/scripts/gha-azure-cred-prep.sh
@@ -16,10 +16,9 @@ for key in "${!secrets[@]}"; do
     finalKey=${lowerKey/tf_var_/TF_VAR_}
     export "$finalKey"="${secrets[$key]}"
     echo "Exported Terraform secret: $finalKey"
-  elif [[ $key = E2E_TEST_* ]]; then
-    finalKey=${key#E2E_TEST_}
-    export "$finalKey"="${secrets[$key]}"
-    echo "Exported E2E test secret: $finalKey"
+  elif [[ $key = AVM_BARE_* ]]; then
+    export "$key"="${secrets[$key]}"
+    echo "Exported AVM bare secret: $key (will be passed to container as ${key#AVM_BARE_})"
   fi
 done
 
@@ -29,10 +28,9 @@ for key in "${!variables[@]}"; do
     finalKey=${lowerKey/tf_var_/TF_VAR_}
     export "$finalKey"="${variables[$key]}"
     echo "Exported Terraform variable: $finalKey"
-  elif [[ $key = E2E_TEST_* ]]; then
-    finalKey=${key#E2E_TEST_}
-    export "$finalKey"="${variables[$key]}"
-    echo "Exported E2E test variable: $finalKey"
+  elif [[ $key = AVM_BARE_* ]]; then
+    export "$key"="${variables[$key]}"
+    echo "Exported AVM bare variable: $key (will be passed to container as ${key#AVM_BARE_})"
   fi
 done
 

--- a/tests/terraform-azure-avm-res-mock/avm
+++ b/tests/terraform-azure-avm-res-mock/avm
@@ -173,6 +173,15 @@ if [ -f "avm.config.json" ]; then
   done
 fi
 
+# Forward AVM_BARE_* environment variables to the container with the prefix stripped
+while IFS='=' read -r bareKey bareValue; do
+  [ -z "$bareKey" ] && continue
+  strippedKey="${bareKey#AVM_BARE_}"
+  export "$strippedKey"="$bareValue"
+  LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $strippedKey "
+  echo "Forwarding AVM bare variable to container as: $strippedKey"
+done < <(env | grep '^AVM_BARE_' || true)
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -199,7 +208,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e TF_IN_AUTOMATION=1 \
     ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
-    --env-file <(env | grep '^AVM_') \
+    --env-file <(env | grep '^AVM_' | grep -v '^AVM_BARE_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \

--- a/tests/terraform-azure-avm-res-mock/avm.ps1
+++ b/tests/terraform-azure-avm-res-mock/avm.ps1
@@ -150,9 +150,16 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
-  # Add AVM_ environment variables
-  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" } | ForEach-Object {
+  # Add AVM_ environment variables (excluding AVM_BARE_* which are forwarded with the prefix stripped)
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" -and $_.Name -notlike "AVM_BARE_*" } | ForEach-Object {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
+  }
+
+  # Forward AVM_BARE_* environment variables to the container with the prefix stripped
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_BARE_*" } | ForEach-Object {
+    $strippedName = $_.Name -replace '^AVM_BARE_', ''
+    $dockerArgs += @("-e", "$strippedName=$($_.Value)")
+    Write-Host "Forwarding AVM bare variable to container as: $strippedName"
   }
 
   # Add local environment variables from avm.config.json

--- a/tests/terraform-azurerm-avm-res-mock/avm
+++ b/tests/terraform-azurerm-avm-res-mock/avm
@@ -173,6 +173,15 @@ if [ -f "avm.config.json" ]; then
   done
 fi
 
+# Forward AVM_BARE_* environment variables to the container with the prefix stripped
+while IFS='=' read -r bareKey bareValue; do
+  [ -z "$bareKey" ] && continue
+  strippedKey="${bareKey#AVM_BARE_}"
+  export "$strippedKey"="$bareValue"
+  LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $strippedKey "
+  echo "Forwarding AVM bare variable to container as: $strippedKey"
+done < <(env | grep '^AVM_BARE_' || true)
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -199,7 +208,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e TF_IN_AUTOMATION=1 \
     ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
-    --env-file <(env | grep '^AVM_') \
+    --env-file <(env | grep '^AVM_' | grep -v '^AVM_BARE_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \

--- a/tests/terraform-azurerm-avm-res-mock/avm.ps1
+++ b/tests/terraform-azurerm-avm-res-mock/avm.ps1
@@ -150,9 +150,16 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
-  # Add AVM_ environment variables
-  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" } | ForEach-Object {
+  # Add AVM_ environment variables (excluding AVM_BARE_* which are forwarded with the prefix stripped)
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" -and $_.Name -notlike "AVM_BARE_*" } | ForEach-Object {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
+  }
+
+  # Forward AVM_BARE_* environment variables to the container with the prefix stripped
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_BARE_*" } | ForEach-Object {
+    $strippedName = $_.Name -replace '^AVM_BARE_', ''
+    $dockerArgs += @("-e", "$strippedName=$($_.Value)")
+    Write-Host "Forwarding AVM bare variable to container as: $strippedName"
   }
 
   # Add local environment variables from avm.config.json

--- a/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
+++ b/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
@@ -242,11 +242,7 @@ $moduleMetaData = $null
 
 if(!$repositoryCreationModeEnabled){
     $moduleMetaData = $repoMetaData
-    if(!$moduleMetaData) {
-        Write-Warning "Module metadata missing for: $($repoId)"
-        $issueLog = Add-IssueToLog -orgAndRepoName $orgAndRepoName -type "module-metadata-missing" -message "Module metadata for $repoId does not exist in meta-data.csv. Add an entry to meta-data.csv." -data $repoId -severity "warning" -issueLog $issueLog
-        $moduleName = $repoId
-    } else {
+    if($moduleMetaData) {
         $moduleName = $moduleMetaData.moduleDisplayName
     }
 } elseif($repoMetaData) {


### PR DESCRIPTION
## Changes

### `scripts/gha-azure-cred-prep.sh` — support `AVM_BARE_`-prefixed vars/secrets
Adds a way to pipe arbitrary environment variables into test runs without forcing them through Terraform. Any GitHub Actions secret or variable prefixed with `AVM_BARE_` is now exported with the prefix intact so the `avm` wrapper can detect it. Existing `TF_VAR_*` handling is unchanged. Each exported `TF_VAR_*` and `AVM_BARE_*` key is logged by name (no values) for visibility.

### `managed-files/root/avm` and `avm.ps1` (plus test mirrors) — forward `AVM_BARE_*` into the container
Both wrappers now scan for `AVM_BARE_*` env vars and forward them to the container with the prefix stripped (via `LOCAL_ENVIRONMENT_VARIABLES`). The existing `AVM_*` passthrough has been narrowed to exclude `AVM_BARE_*` so the un-stripped versions do not leak into the container. Mirror copies in `tests/terraform-azure-avm-res-mock/` and `tests/terraform-azurerm-avm-res-mock/` were updated to match.

### `tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1` — remove duplicate metadata warning
The `module-metadata-missing` warning was being emitted in two places. The matrix generator in `.github/actions/avm-repos/scripts/Get-RepositoriesWhereAppInstalled.ps1` already raises this warning and persists it to `issues.log.json`, so the duplicate in `Invoke-RepositorySync.ps1` has been removed.

## How to use `AVM_BARE_*`

In the calling repo, add a GitHub Actions secret or variable named `AVM_BARE_MY_VAR=<value>`. After `gha-azure-cred-prep.sh` runs, the AVM wrapper will forward it into the container as `MY_VAR=<value>`, where tests/tooling can read it directly without needing the `TF_VAR_` prefix.
