### PR TITLE
chore: remove valid_template_interpolation tflint rule

### DIFF
--- a/tflint-configs/avm.tflint.hcl
+++ b/tflint-configs/avm.tflint.hcl
@@ -191,7 +191,3 @@ rule "tags" {
 rule "provider_modtm_version_constraint" {
   enabled = true
 }
-
-rule "valid_template_interpolation" {
-  enabled = true
-}

--- a/tflint-configs/avm.tflint_example.hcl
+++ b/tflint-configs/avm.tflint_example.hcl
@@ -191,7 +191,3 @@ rule "tags" {
 rule "provider_modtm_version_constraint" {
   enabled = false
 }
-
-rule "valid_template_interpolation" {
-  enabled = true
-}

--- a/tflint-configs/avm.tflint_module.hcl
+++ b/tflint-configs/avm.tflint_module.hcl
@@ -192,7 +192,3 @@ rule "tags" {
 rule "provider_modtm_version_constraint" {
   enabled = false
 }
-
-rule "valid_template_interpolation" {
-  enabled = true
-}


### PR DESCRIPTION
## Summary

Removes the `valid_template_interpolation` rule from the three tflint config files in `tflint-configs/`:

- `avm.tflint.hcl`
- `avm.tflint_example.hcl`
- `avm.tflint_module.hcl`

## Rationale

The `valid_template_interpolation` rule has been deprecated/removed in newer versions of the tflint terraform ruleset and was producing warnings during lint runs. Removing it cleans up the rule list with no loss of meaningful coverage.

## Scope

- No changes to grept policies, managed files, or pipeline configs.
- No functional change to other tflint rules.
