### PR TITLE
Change moduleProvider from 'azurerm' to 'azure'

### DIFF
--- a/tf-repo-mgmt/scripts/New-Repository.ps1
+++ b/tf-repo-mgmt/scripts/New-Repository.ps1
@@ -2,7 +2,7 @@ param (
   [string]$tempPath = "~/temp-avm-repo-creation",
   [string]$governanceRepoUrl = "https://github.com/Azure/avm-terraform-governance",
   [string]$openSourceRepoUrl = "https://github.com/microsoft/github-operations",
-  [string]$moduleProvider = "azurerm",
+  [string]$moduleProvider = "azure",
   [string]$moduleName,
   [string]$moduleDisplayName,
   [string]$resourceProviderNamespace,


### PR DESCRIPTION
This pull request makes a minor update to the default value of the `moduleProvider` parameter in the `New-Repository.ps1` script, changing it from `"azurerm"` to `"azure"`.

* Changed the default value of the `moduleProvider` parameter in `tf-repo-mgmt/scripts/New-Repository.ps1` from `"azurerm"` to `"azure"` to reflect updated naming conventions or provider usage.