### PR TITLE
feat(porch): auto-source per-example .env file before terraform steps

### DIFF
--- a/porch-configs/README.md
+++ b/porch-configs/README.md
@@ -97,3 +97,52 @@ The root level commands are always run in series.
       name: Will be run concurrently as well!
       command_line: |
         echo "This is the second step in a parallel group"
+```
+
+## Per-example hooks and `.env` auto-sourcing
+
+The per-example `foreachdirectory` blocks in [`test-examples.porch.yaml`](./test-examples.porch.yaml) and the `well architected` block in [`pr-check.porch.yaml`](./pr-check.porch.yaml) provide optional per-example hook scripts that run inside each example's working directory:
+
+- `pre.sh` / `pre.ps1` — run before the terraform steps.
+- `post.sh` / `post.ps1` — run after the terraform steps (always, including on failure).
+
+Each step in a Porch run executes in its own subprocess, so environment variables `export`ed from `pre.sh` / `pre.ps1` do not propagate to the subsequent `terraform init` / `terraform plan` / `terraform apply` / `terraform destroy` steps.
+
+To bridge this, every terraform step in those blocks auto-sources a file named `.env` from the example's working directory if one exists:
+
+```bash
+set -a; [ -f .env ] && . ./.env; set +a
+terraform <command>
+```
+
+`set -a` causes assignments in `.env` to be auto-exported, so the `terraform` process (and any subprocess it spawns, e.g. `gh` via `local-exec`) inherits them as real environment variables for that step only. File presence is the opt-in — examples without a `.env` are unaffected.
+
+### Usage
+
+If your example needs an env var that should not be set on the host (for example, a token that would interfere with local `gh` authentication), have your `pre.sh` write a `.env` file in the example directory and your `post.sh` remove it:
+
+```bash
+# pre.sh
+cat > .env <<EOF
+GITHUB_TOKEN=${AVM_E2E_GITHUB_TOKEN}
+EOF
+```
+
+```bash
+# post.sh
+rm -f .env
+```
+
+Add `.env` to your module's `.gitignore` so it is never committed.
+
+> If pwsh-typed terraform steps are added to these configs in the future, use the analogous PowerShell preamble:
+>
+> ```powershell
+> if (Test-Path .env) {
+>   Get-Content .env | ForEach-Object {
+>     if ($_ -match '^([^=]+)=(.*)$') {
+>       [Environment]::SetEnvironmentVariable($Matches[1], $Matches[2])
+>     }
+>   }
+> }
+> ```

--- a/porch-configs/pr-check.porch.yaml
+++ b/porch-configs/pr-check.porch.yaml
@@ -365,12 +365,16 @@ commands:
           # conftest
           - type: shell
             name: terraform init
-            command_line: terraform init -input=false
+            command_line: |
+              set -a; [ -f .env ] && . ./.env; set +a
+              terraform init -input=false
 
           # conftest
           - name: terraform plan
             type: shell
-            command_line: terraform plan -out=tfplan -input=false
+            command_line: |
+              set -a; [ -f .env ] && . ./.env; set +a
+              terraform plan -out=tfplan -input=false
 
             # conftest
           - name: terraform show

--- a/porch-configs/test-examples.porch.yaml
+++ b/porch-configs/test-examples.porch.yaml
@@ -102,19 +102,27 @@ commands:
 
       - type: shell
         name: Terraform Init
-        command_line: terraform init
+        command_line: |
+          set -a; [ -f .env ] && . ./.env; set +a
+          terraform init
 
       - type: shell
         name: Terraform Plan
-        command_line: terraform plan -out tfplan
+        command_line: |
+          set -a; [ -f .env ] && . ./.env; set +a
+          terraform plan -out tfplan
 
       - type: shell
         name: Terraform Apply
-        command_line: terraform apply -auto-approve tfplan
+        command_line: |
+          set -a; [ -f .env ] && . ./.env; set +a
+          terraform apply -auto-approve tfplan
 
       - type: shell
         name: Terraform Plan Idempotency Check
-        command_line: terraform plan -detailed-exitcode -out tfplan
+        command_line: |
+          set -a; [ -f .env ] && . ./.env; set +a
+          terraform plan -detailed-exitcode -out tfplan
 
         # This command will run if the previous plan was not idempotent
         # and will output the plan to stderr.
@@ -132,6 +140,7 @@ commands:
             exit 0
           fi
           ls -al 1>&2
+          set -a; [ -f .env ] && . ./.env; set +a
           terraform destroy -auto-approve
         runs_on_condition: always
 


### PR DESCRIPTION
## Summary

Each command inside a porch `foreachdirectory` step runs in its own subprocess, so env vars exported from `pre.sh` / `pre.ps1` do not propagate to the subsequent `terraform init` / `plan` / `apply` / `destroy` steps. This blocks per-example patterns that need to surface a real env var to terraform (e.g. `GITHUB_TOKEN` for the `github` provider's data sources, or `gh` cli invocations from `local-exec`) without polluting the host environment.

This PR introduces an opt-in convention: every terraform step in the per-example `foreachdirectory` blocks now auto-sources a `.env` file in the example's working directory if one exists:

```bash
set -a; [ -f .env ] && . ./.env; set +a
terraform <command>
```

`set -a` auto-exports assignments in `.env` so the spawned `terraform` process (and any subprocess it spawns) inherits them as real env vars **for that step only**. File presence is the opt-in — examples without a `.env` are completely unaffected.

## Changes

- `porch-configs/test-examples.porch.yaml` — prepend the source line to `Terraform Init`, `Terraform Plan`, `Terraform Apply`, `Terraform Plan Idempotency Check`, and `Terraform Destroy`.
- `porch-configs/pr-check.porch.yaml` — prepend the source line to `terraform init` and `terraform plan` in the `well architected` per-example block. (`terraform show` / `conftest` steps don't resolve providers/data sources, so they are intentionally untouched.)
- `porch-configs/README.md` — add a "Per-example hooks and `.env` auto-sourcing" section documenting the convention, including a PowerShell preamble to use if pwsh-typed terraform steps are added later.

## Non-goals / constraints

- The existing `pre.sh` / `pre.ps1` / `post.sh` / `post.ps1` hook steps are **unchanged**.
- No new required env var or porch feature — purely a yaml-level convention.
- Porch does not write `.env`; that is the consumer module's responsibility (their `pre.sh` writes it, their `post.sh` removes it, their `.gitignore` excludes it).
- **Backward compatible**: examples that don't write a `.env` see no change in behavior.

## Motivating consumer

[`Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners`](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners) — its GitHub examples need `GITHUB_TOKEN` set as a real env var so:

1. The `github` terraform provider can call `data "github_organization"` (org-scoped read).
2. `gh` cli invocations (e.g. via `local-exec`) inside the example can authenticate.

The consumer doesn't want to set `GITHUB_TOKEN` on the host (it interferes with host `gh` auth and linting), so they pass it in as `AVM_E2E_GITHUB_TOKEN` and want a `pre.sh` to map it to `GITHUB_TOKEN` inside the porch run. Today that's impossible because env doesn't propagate; with this PR a `pre.sh` that writes `.env` makes it work.

## Verification

1. Apply the yaml changes (this PR).
2. In a sibling consumer repo with `pre.sh` that writes `.env`, `post.sh` that removes it, and `.env` in `.gitignore`, point porch at this branch.
3. Confirm `terraform plan` against the GitHub examples succeeds (previously failed with `Error: Resource not accessible by integration` from `data "github_organization"`).
4. Confirm examples without a `.env` file still run identically (no new errors, same output).
