### PR TITLE
feat(gha-cred-prep): export all AVM_-prefixed env vars

### DIFF
--- a/scripts/gha-azure-cred-prep.sh
+++ b/scripts/gha-azure-cred-prep.sh
@@ -19,6 +19,9 @@ for key in "${!secrets[@]}"; do
   elif [[ $key = AVM_BARE_* ]]; then
     export "$key"="${secrets[$key]}"
     echo "Exported AVM bare secret: $key (will be passed to container as ${key#AVM_BARE_})"
+  elif [[ $key = AVM_* ]]; then
+    export "$key"="${secrets[$key]}"
+    echo "Exported AVM secret: $key"
   fi
 done
 
@@ -31,6 +34,9 @@ for key in "${!variables[@]}"; do
   elif [[ $key = AVM_BARE_* ]]; then
     export "$key"="${variables[$key]}"
     echo "Exported AVM bare variable: $key (will be passed to container as ${key#AVM_BARE_})"
+  elif [[ $key = AVM_* ]]; then
+    export "$key"="${variables[$key]}"
+    echo "Exported AVM variable: $key"
   fi
 done
 


### PR DESCRIPTION
## Summary

`scripts/gha-azure-cred-prep.sh` currently exports only two prefix families from the GitHub Actions `secrets` and `vars` contexts:

- `TF_VAR_*` → exported as `TF_VAR_*` (with case fix-up)
- `AVM_BARE_*` → exported as-is (with a log message about container-side prefix stripping)

Any other `AVM_`-prefixed value — for example `AVM_E2E_GITHUB_TOKEN` that a consumer module wants to surface to its porch examples (e.g. to write into a per-example `.env` file from `pre.sh`, see #459) — is silently dropped before the porch run starts.

This PR adds a generic `AVM_*` fallback branch in both the secrets and variables loops, after the existing `AVM_BARE_*` branch. `elif` ordering preserves the `AVM_BARE_*`-specific log message about container-side prefix stripping; any GH Actions secret or variable whose key starts with `AVM_` (and isn't already matched by the more specific `AVM_BARE_*` branch) is now exported as-is to the runner environment.

## Changes

- `scripts/gha-azure-cred-prep.sh` — add `elif [[ $key = AVM_* ]]` branch after the existing `AVM_BARE_*` branch in both the secrets loop and the variables loop.

## Compatibility

- Backward compatible: `TF_VAR_*` and `AVM_BARE_*` keys are handled exactly as before (same export, same log messages).
- New behavior is purely additive — only previously-dropped `AVM_*` keys are affected.

## Motivation

Pairs with #459. The `.env` auto-sourcing convention added there relies on consumer-side `pre.sh` scripts being able to read AVM-prefixed env vars (e.g. `AVM_E2E_GITHUB_TOKEN`) and write them into a per-example `.env` file. For that to work end-to-end in CI, the cred prep script has to actually export those vars from the GH Actions context to the runner environment first.
