### PR TITLE
feat: automate fork PR handoff to release branch for e2e tests

### DIFF
--- a/.github/workflows/fork-pr-handoff.yml
+++ b/.github/workflows/fork-pr-handoff.yml
@@ -1,0 +1,222 @@
+---
+name: Fork PR Handoff
+
+# End-to-end tests in module repos cannot run on PRs from forks because GitHub
+# does not expose secrets to fork-triggered workflows. This workflow performs a
+# one-shot, maintainer-owned handoff:
+#
+#   1. Creates an `e2e/pr-<N>` branch from `main` in the target module repo.
+#   2. Retargets the fork PR's base to that branch.
+#   3. Squash-merges the fork PR (preserving the original author and emitting
+#      Co-authored-by trailers for every commit author).
+#   4. Opens a release-branch PR (`e2e/pr-<N>` -> `main`) on which the standard
+#      pr-check.yml runs with full credentials.
+#   5. Comments on the (now closed) fork PR linking the release-branch PR.
+#
+# From the handoff onward, the module owners are responsible for the change.
+# Any further changes are made on the release-branch PR, not on the original
+# fork PR.
+#
+# The workflow lives in the governance repo because module repos do not have
+# the AVM GitHub App credentials, and only an App token can create the release
+# branch PR in a way that triggers the downstream pr-check.yml workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: 'Target module repository in owner/name form (e.g. Azure/terraform-azurerm-avm-res-storage-storageaccount).'
+        type: string
+        required: true
+      pr_number:
+        description: 'Number of the fork PR to hand off to a release branch.'
+        type: number
+        required: true
+  repository_dispatch:
+    types: [fork-pr-handoff]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-pr-handoff-${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_repo || inputs.target_repo }}-${{ github.event_name == 'repository_dispatch' && github.event.client_payload.pr_number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  handoff:
+    name: Hand off fork PR
+    runs-on: ubuntu-latest
+    environment: avm
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve inputs
+        id: resolve
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "repository_dispatch") {
+            $target = "${{ github.event.client_payload.target_repo }}"
+            $pr     = "${{ github.event.client_payload.pr_number }}"
+          } else {
+            $target = "${{ inputs.target_repo }}"
+            $pr     = "${{ inputs.pr_number }}"
+          }
+
+          if ([string]::IsNullOrWhiteSpace($target)) { throw "target_repo is required." }
+          if ([string]::IsNullOrWhiteSpace($pr))     { throw "pr_number is required." }
+          if ($target -notmatch '^[^/]+/[^/]+$')     { throw "target_repo '$target' must be in owner/name form." }
+          if (-not [int]::TryParse($pr, [ref]$null)) { throw "pr_number '$pr' must be an integer." }
+
+          $owner, $name = $target.Split('/')
+          Write-Output "target_repo=$target"   >> $env:GITHUB_OUTPUT
+          Write-Output "target_owner=$owner"   >> $env:GITHUB_OUTPUT
+          Write-Output "target_name=$name"     >> $env:GITHUB_OUTPUT
+          Write-Output "pr_number=$pr"         >> $env:GITHUB_OUTPUT
+          Write-Host "Handing off fork PR #$pr in $target."
+
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
+          owner: ${{ steps.resolve.outputs.target_owner }}
+          repositories: ${{ steps.resolve.outputs.target_name }}
+
+      - name: Hand off fork PR to release branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_REPO: ${{ steps.resolve.outputs.target_repo }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo     = $env:TARGET_REPO
+          $prNumber = [int]$env:PR_NUMBER
+
+          function Assert-GhOk {
+            param([string]$Operation)
+            if ($LASTEXITCODE -ne 0) { throw "$Operation failed (gh exit $LASTEXITCODE)." }
+          }
+
+          Write-Host "Looking up fork PR #$prNumber in $repo..."
+          $prJson = gh pr view $prNumber --repo $repo --json 'number,title,body,state,isCrossRepository,isDraft,headRefName,author,commits'
+          Assert-GhOk "gh pr view #$prNumber"
+          $pr = $prJson | ConvertFrom-Json
+
+          if ($pr.state -ne 'OPEN')   { throw "Fork PR #$($pr.number) is not open (state=$($pr.state))." }
+          if (-not $pr.isCrossRepository) { throw "PR #$($pr.number) is not from a fork; use the standard flow." }
+          if ($pr.isDraft)            { throw "PR #$($pr.number) is a draft. Mark it ready for review first." }
+
+          $branch = "e2e/pr-$($pr.number)"
+          Write-Host "Release branch will be '$branch'."
+
+          # Refuse to overwrite an existing release branch.
+          gh api "repos/$repo/git/ref/heads/$branch" 2>$null | Out-Null
+          $branchExists = ($LASTEXITCODE -eq 0)
+          $global:LASTEXITCODE = 0
+          if ($branchExists) {
+            throw "Branch '$branch' already exists in $repo. Delete it manually and re-run if a fresh handoff is genuinely needed."
+          }
+
+          # Resolve main's tip and create the release branch from it.
+          $mainRefJson = gh api "repos/$repo/git/ref/heads/main"
+          Assert-GhOk "gh api git/ref/heads/main"
+          $mainSha = ($mainRefJson | ConvertFrom-Json).object.sha
+          Write-Host "main tip: $mainSha"
+
+          gh api "repos/$repo/git/refs" --method POST -f "ref=refs/heads/$branch" -f "sha=$mainSha" | Out-Null
+          Assert-GhOk "create branch $branch"
+          Write-Host "Created branch '$branch' from main."
+
+          # Build Co-authored-by trailers from the distinct commit authors on the fork PR.
+          $authorSet = [System.Collections.Generic.HashSet[string]]::new()
+          foreach ($commit in $pr.commits) {
+            foreach ($author in $commit.authors) {
+              if ([string]::IsNullOrWhiteSpace($author.email)) { continue }
+              if ([string]::IsNullOrWhiteSpace($author.name))  { continue }
+              if ($author.login -and $author.login.EndsWith('[bot]')) { continue }
+              [void]$authorSet.Add("Co-authored-by: $($author.name) <$($author.email)>")
+            }
+          }
+          $trailers = ($authorSet | Sort-Object) -join "`n"
+
+          # Retarget the fork PR's base from main to the release branch.
+          gh pr edit $prNumber --repo $repo --base $branch | Out-Null
+          Assert-GhOk "gh pr edit --base"
+          Write-Host "Retargeted PR #$prNumber base to '$branch'."
+
+          # Poll for GitHub to recompute mergeability after the base change.
+          $ready = $false
+          for ($i = 0; $i -lt 6 -and -not $ready; $i++) {
+            Start-Sleep -Seconds 5
+            $checkJson = gh pr view $prNumber --repo $repo --json 'mergeable,mergeStateStatus'
+            Assert-GhOk "gh pr view (mergeability)"
+            $check = $checkJson | ConvertFrom-Json
+            Write-Host "Mergeability attempt $($i + 1): mergeable=$($check.mergeable), state=$($check.mergeStateStatus)"
+            if ($check.mergeable -eq 'CONFLICTING') {
+              throw "Fork PR #$prNumber has merge conflicts against main. Ask the contributor to rebase their fork before handoff."
+            }
+            if ($check.mergeable -eq 'MERGEABLE') { $ready = $true }
+          }
+          if (-not $ready) { throw "Timed out waiting for GitHub to compute mergeability after base retargeting." }
+
+          # Synthesize the squash commit message.
+          $mergeSubject = "$($pr.title) (#$prNumber)"
+          $bodyParts = @()
+          if (-not [string]::IsNullOrWhiteSpace($pr.body)) { $bodyParts += $pr.body.Trim() }
+          $bodyParts += "Closes #$prNumber"
+          if (-not [string]::IsNullOrWhiteSpace($trailers)) { $bodyParts += $trailers }
+          $mergeBody = $bodyParts -join "`n`n"
+
+          # Squash-merge the fork PR. GitHub auto-closes the fork PR on merge.
+          gh pr merge $prNumber --repo $repo --squash --subject $mergeSubject --body $mergeBody | Out-Null
+          Assert-GhOk "gh pr merge --squash"
+          Write-Host "Squash-merged fork PR #$prNumber into '$branch'."
+
+          # Open the release-branch PR. The PR body re-asserts the Co-authored-by
+          # trailers so they survive whichever squash-message mode the repo uses.
+          $author   = $pr.author.login
+          $relTitle = "$($pr.title) (release branch for fork PR #$prNumber)"
+          $relBody  = @"
+          This release-branch PR continues the work from fork PR #$prNumber by @$author.
+
+          The original fork PR has been squash-merged into the ``$branch`` release branch so the end-to-end test workflows (which require Azure credentials and therefore cannot run on fork PRs) can execute against the change. From this point on, the module owners are responsible for landing this change. Any further changes will be made on **this** PR; the original fork PR is closed and will not receive further commits.
+
+          Original fork PR: #$prNumber
+
+          $trailers
+          "@.Trim()
+
+          $relPrUrl = gh pr create --repo $repo --base main --head $branch --title $relTitle --body $relBody
+          Assert-GhOk "gh pr create"
+          $relPrUrl = ($relPrUrl | Select-Object -Last 1).Trim()
+
+          $relPrNumber = (gh pr view $relPrUrl --repo $repo --json number | ConvertFrom-Json).number
+          Assert-GhOk "gh pr view (release PR)"
+          Write-Host "Opened release-branch PR #${relPrNumber}: $relPrUrl"
+
+          # Comment on the (now closed) fork PR linking the release-branch PR.
+          $forkComment = "Thanks for the contribution, @$author! This PR has been squash-merged into the release branch ``$branch`` so the end-to-end tests can run. Continued review and any follow-up will happen on the release-branch PR #$relPrNumber."
+          gh pr comment $prNumber --repo $repo --body $forkComment | Out-Null
+          Assert-GhOk "gh pr comment"
+
+          # Best-effort label both PRs. Label creation may fail if it already exists; that's fine.
+          gh label create e2e-handoff --repo $repo --color BFD4F2 --description 'Fork PR handed off to a release branch for end-to-end testing.' 2>$null | Out-Null
+          $global:LASTEXITCODE = 0
+          gh pr edit $prNumber    --repo $repo --add-label e2e-handoff 2>$null | Out-Null
+          $global:LASTEXITCODE = 0
+          gh pr edit $relPrNumber --repo $repo --add-label e2e-handoff 2>$null | Out-Null
+          $global:LASTEXITCODE = 0
+
+          Write-Host "::notice title=Fork PR handoff complete::Fork PR #$prNumber in $repo handed off to release-branch PR #$relPrNumber."
+
+          @"
+          ## Fork PR handoff complete
+
+          - **Target repository:** ``$repo``
+          - **Source fork PR:** #$prNumber (closed)
+          - **Release branch:** ``$branch``
+          - **Release-branch PR:** #$relPrNumber ($relPrUrl)
+          - **Original contributor:** @$author
+          "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -34,6 +34,9 @@ defaults:
 
 jobs:
   generate-matrix:
+    # Ignore repository_dispatch events that target other workflows (e.g. fork-pr-handoff).
+    # Without this guard, any `gh api repos/.../dispatches` call would also trigger a repo sync.
+    if: github.event_name != 'repository_dispatch' || github.event.action != 'fork-pr-handoff'
     name: Generate Matrix
     runs-on: ubuntu-latest
     environment: avm

--- a/managed-files/root/.agents/skills/avm-terraform-module-development/SKILL.md
+++ b/managed-files/root/.agents/skills/avm-terraform-module-development/SKILL.md
@@ -184,6 +184,43 @@ When creating the PR, include:
 - The issue number(s) the PR closes.
 - Any relevant context for reviewers.
 
+## Handling fork PRs
+
+End-to-end tests cannot run on PRs from forks — GitHub does not expose secrets to fork-triggered workflows, so `pr-check.yml` short-circuits with a warning. The standard flow when a fork PR is ready to land:
+
+1. Review the fork PR normally (read the diff, request changes via review comments). Iterate with the contributor on their fork until the change is ready.
+2. **Hand the PR off to a release branch** in the upstream module repo. The handoff workflow (in `Azure/avm-terraform-governance`):
+   - Creates an `e2e/pr-<N>` branch from `main` in the module repo.
+   - Retargets the fork PR's base from `main` to `e2e/pr-<N>`.
+   - Squash-merges the fork PR into `e2e/pr-<N>`, preserving the original author and emitting `Co-authored-by:` trailers for every commit author.
+   - Closes the fork PR (auto-closed by the squash-merge) and comments on it with a link to the new PR.
+   - Opens a release-branch PR (`e2e/pr-<N>` → `main`) on which `pr-check.yml` runs with full credentials.
+3. **From the handoff onward, the module owners own the change.** Any further work — review fixes, conflict resolution, lint fixes — happens on the release-branch PR, **not** the original fork PR. The fork PR is closed and will not receive further commits.
+4. Squash-merge the release-branch PR as usual. The `Co-authored-by:` trailers in the PR body keep crediting the original contributor on the final commit.
+
+### Trigger the handoff
+
+Two equivalent options.
+
+**From the governance Actions UI:** run the `Fork PR Handoff` workflow in `Azure/avm-terraform-governance`, supplying `target_repo` (e.g. `Azure/terraform-azurerm-avm-res-storage-storageaccount`) and `pr_number`.
+
+**From the agent or a local shell** using `gh`:
+
+```pwsh
+'{"event_type":"fork-pr-handoff","client_payload":{"target_repo":"Azure/<this-module-repo>","pr_number":<fork-pr-number>}}' |
+  gh api repos/Azure/avm-terraform-governance/dispatches --method POST --input -
+```
+
+For polling and richer error handling, the governance repo also exposes [`tf-repo-mgmt/scripts/Invoke-ForkPrHandoff.ps1`](https://github.com/Azure/avm-terraform-governance/blob/main/tf-repo-mgmt/scripts/Invoke-ForkPrHandoff.ps1).
+
+### Pre-flight checks the workflow enforces
+
+The handoff workflow refuses to proceed when:
+
+- The fork PR is not open, or is not from a fork, or is in draft.
+- The fork PR has merge conflicts against `main` — ask the contributor to rebase their fork first.
+- An `e2e/pr-<N>` branch already exists — delete it first if a re-handoff is genuinely needed.
+
 ## Common mistakes to avoid
 
 - **Citing a spec from memory.** AVM specs change. Always fetch the current text via `llms.txt`. Several spec IDs are easy to mix up (e.g. `TFFR4` is `response_export_values`, `TFFR5` is `replace_triggers_refs`, `TFFR6` is `resource_types`, `TFFR7` is `retry`/`timeouts`).

--- a/tf-repo-mgmt/scripts/Invoke-ForkPrHandoff.ps1
+++ b/tf-repo-mgmt/scripts/Invoke-ForkPrHandoff.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+Dispatches the central fork-pr-handoff workflow in the AVM Terraform governance
+repo for a given module repository's fork PR, and (optionally) watches the run
+to completion.
+
+.DESCRIPTION
+End-to-end test workflows in AVM module repos cannot run on PRs from forks
+because GitHub does not expose secrets to fork-triggered workflows. The
+fork-pr-handoff workflow in Azure/avm-terraform-governance performs a
+one-shot, maintainer-owned handoff: it creates an `e2e/pr-<N>` release branch
+in the module repo, squash-merges the fork PR into it (preserving the original
+author and Co-authored-by trailers), closes the fork PR, and opens a
+release-branch PR on which pr-check.yml runs with full credentials.
+
+This script triggers the workflow via repository_dispatch. The caller's
+authenticated `gh` session is used.
+
+.PARAMETER TargetRepo
+The owner/name of the module repository hosting the fork PR
+(e.g. Azure/terraform-azurerm-avm-res-storage-storageaccount).
+
+.PARAMETER PrNumber
+The number of the fork PR to hand off.
+
+.PARAMETER GovernanceRepo
+The governance repo hosting the workflow. Defaults to Azure/avm-terraform-governance.
+
+.PARAMETER WaitForCompletion
+When $true (default), polls the resulting workflow run until it completes and
+throws if it failed.
+
+.PARAMETER WaitTimeoutSeconds
+Maximum seconds to wait when -WaitForCompletion is $true. Defaults to 600.
+
+.EXAMPLE
+./Invoke-ForkPrHandoff.ps1 `
+  -TargetRepo Azure/terraform-azurerm-avm-res-storage-storageaccount `
+  -PrNumber 123
+#>
+param(
+  [Parameter(Mandatory)]
+  [ValidatePattern('^[^/]+/[^/]+$')]
+  [string]$TargetRepo,
+
+  [Parameter(Mandatory)]
+  [ValidateRange(1, 2147483647)]
+  [int]$PrNumber,
+
+  [string]$GovernanceRepo = "Azure/avm-terraform-governance",
+
+  [bool]$WaitForCompletion = $true,
+
+  [int]$WaitTimeoutSeconds = 600
+)
+
+$ErrorActionPreference = 'Stop'
+
+& gh --version *>$null
+if ($LASTEXITCODE -ne 0) {
+  throw "GitHub CLI ('gh') is not installed or not on PATH. See https://cli.github.com/."
+}
+
+& gh auth status *>$null
+if ($LASTEXITCODE -ne 0) {
+  throw "GitHub CLI is not authenticated. Run 'gh auth login' first."
+}
+
+$beforeDispatch = (Get-Date).ToUniversalTime()
+
+Write-Host "Dispatching fork-pr-handoff in $GovernanceRepo for fork PR #$PrNumber in $TargetRepo..."
+
+$payload = @{
+  event_type     = 'fork-pr-handoff'
+  client_payload = @{
+    target_repo = $TargetRepo
+    pr_number   = $PrNumber
+  }
+} | ConvertTo-Json -Depth 5 -Compress
+
+# Use a temp file to avoid stdin/pipe edge cases with native commands.
+$tempFile = New-TemporaryFile
+try {
+  $payload | Out-File -FilePath $tempFile -Encoding utf8 -NoNewline
+  gh api "repos/$GovernanceRepo/dispatches" --method POST --input $tempFile.FullName
+  $dispatchExit = $LASTEXITCODE
+} finally {
+  Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+}
+if ($dispatchExit -ne 0) {
+  throw "Failed to dispatch fork-pr-handoff to $GovernanceRepo (gh exit $dispatchExit)."
+}
+
+Write-Host "Dispatch sent. Locating workflow run..."
+
+$run = $null
+for ($i = 0; $i -lt 12 -and -not $run; $i++) {
+  Start-Sleep -Seconds 5
+  $runsJson = gh run list --repo $GovernanceRepo --workflow fork-pr-handoff.yml --event repository_dispatch --limit 5 --json databaseId,url,status,conclusion,createdAt
+  if ($LASTEXITCODE -ne 0) { continue }
+  $runs = $runsJson | ConvertFrom-Json
+  if ($runs) {
+    $run = $runs | Where-Object { ([datetime]$_.createdAt).ToUniversalTime() -ge $beforeDispatch.AddSeconds(-30) } | Select-Object -First 1
+  }
+  if (-not $run) { Write-Host "Run not yet visible (attempt $($i + 1) of 12)..." }
+}
+
+if (-not $run) {
+  Write-Warning "Could not locate the dispatched run. It may still be queueing. Check https://github.com/$GovernanceRepo/actions/workflows/fork-pr-handoff.yml"
+  return
+}
+
+Write-Host "Workflow run: $($run.url)"
+
+if (-not $WaitForCompletion) {
+  return
+}
+
+Write-Host "Watching run to completion (timeout: ${WaitTimeoutSeconds}s)..."
+$watchJob = Start-Job -ScriptBlock {
+  param($runId, $repo)
+  & gh run watch $runId --repo $repo --exit-status
+  $LASTEXITCODE
+} -ArgumentList $run.databaseId, $GovernanceRepo
+
+$completed = Wait-Job -Job $watchJob -Timeout $WaitTimeoutSeconds
+if (-not $completed) {
+  Stop-Job -Job $watchJob -ErrorAction SilentlyContinue
+  Remove-Job -Job $watchJob -Force -ErrorAction SilentlyContinue
+  throw "Timed out after ${WaitTimeoutSeconds}s waiting for fork-pr-handoff run. See $($run.url)."
+}
+
+$exitCode = Receive-Job -Job $watchJob
+Remove-Job -Job $watchJob -Force -ErrorAction SilentlyContinue
+if ($exitCode -ne 0) {
+  throw "Fork PR handoff workflow failed (exit $exitCode). See $($run.url)."
+}
+
+Write-Host "Fork PR handoff completed successfully."


### PR DESCRIPTION
## Summary

Fork PRs cannot run `pr-check.yml` because GitHub does not expose secrets to workflows triggered by forks. This PR adds a one-shot handoff that moves a fork PR onto an `e2e/pr-<N>` release branch in the target module repo so e2e workflows can run with credentials.

## What changed

| File | Purpose |
|---|---|
| `.github/workflows/fork-pr-handoff.yml` | **New.** Central reusable workflow. Triggers: `workflow_dispatch` + `repository_dispatch` (type `fork-pr-handoff`). Creates `e2e/pr-<N>`, retargets the fork PR base, squash-merges (auto-closes fork PR), opens release-branch PR with `Co-authored-by:` trailers, comments back on the fork PR. |
| `tf-repo-mgmt/scripts/Invoke-ForkPrHandoff.ps1` | **New.** Trigger script for agents / maintainers. Dispatches the `repository_dispatch` event via `gh api` and optionally polls `gh run watch`. |
| `.github/workflows/tf-repo-mgmt.yml` | Added an `if:` guard on `generate-matrix` so the new `fork-pr-handoff` dispatch event does not cross-fire the repo sync workflow. |
| `managed-files/root/.agents/skills/avm-terraform-module-development/SKILL.md` | New `## Handling fork PRs` section. Will sync to all module repos via the existing grept managed-files rule. |

## Design note

Central-only, not per-repo wrapper. Two constraints forced this:

1. Module repos do not have `AVM_APP_*` secrets — only the governance repo's `avm` environment does.
2. The default `GITHUB_TOKEN` does not trigger downstream workflows, so a per-repo wrapper using `GITHUB_TOKEN` would create the release-branch PR but `pr-check.yml` would never run on it.

The workflow therefore lives here and uses the App token, scoped per-call to the target module repo via `actions/create-github-app-token`''s `repositories:` input.

## How to use

```pwsh
# From any shell with gh authenticated:
''{"event_type":"fork-pr-handoff","client_payload":{"target_repo":"Azure/<module-repo>","pr_number":<N>}}'' |
  gh api repos/Azure/avm-terraform-governance/dispatches --method POST --input -

# Or with polling:
./tf-repo-mgmt/scripts/Invoke-ForkPrHandoff.ps1 -TargetRepo Azure/<module-repo> -PrNumber <N>

# Or browser: Actions -> Fork PR Handoff -> Run workflow
```

## Pre-flight rejections (intentional)

The workflow refuses to proceed if the fork PR is not open, not from a fork, in draft, has merge conflicts, or if `e2e/pr-<N>` already exists.

## Out of scope

- No per-repo wrapper (eliminated by token constraint above).
- No re-handoff logic — one-shot only; module owners take over at merge time and any further changes happen on the release-branch PR.
- Mock-repo `.agents/...` files will be re-synced from `managed-files/root` by the governance-test workflow on its next run.