### PR TITLE
chore: add deprecated workflow + bump GitHub Actions to latest SHA-pinned versions

### DIFF
--- a/.github/actions/avm-repos/action.yml
+++ b/.github/actions/avm-repos/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Create GitHub App Token
       id: app-token
-      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         client-id: ${{ inputs.clientId }}
         private-key: ${{ inputs.privateKey }}

--- a/.github/workflows/admin-merge-pre-commit-prs.yml
+++ b/.github/workflows/admin-merge-pre-commit-prs.yml
@@ -30,7 +30,7 @@ jobs:
       matrixParallel: ${{ steps.matrix.outputs.matrixParallel }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Generate Matrix
         uses: ./.github/actions/avm-repos

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -47,11 +47,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ secrets.ACR_SERVER_URL }}
           username: ${{ secrets.ACR_USERNAME }}
@@ -65,7 +65,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ secrets.ACR_SERVER_URL }}/${{ matrix.image.repo }}
@@ -86,13 +86,13 @@ jobs:
         working-directory: ./container
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
           platforms: ${{ env.PLATFORMS }}
           cache-image: true
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           version: latest
 
@@ -101,7 +101,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push image
         id: push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./container
           push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/governance-test.yml
+++ b/.github/workflows/governance-test.yml
@@ -50,7 +50,7 @@ jobs:
     environment: avm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
         id: readenv
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
@@ -67,7 +67,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             avm
@@ -75,7 +75,7 @@ jobs:
             type=raw,value=test
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           version: latest
 
@@ -90,7 +90,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build image
         id: push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./container
           push: false
@@ -167,14 +167,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           ref: ${{ github.head_ref }} # Checkout the branch of the PR, not the default sha
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}

--- a/.github/workflows/managed-pr-check.yml
+++ b/.github/workflows/managed-pr-check.yml
@@ -61,10 +61,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 #v5.2.0
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
       - name: Run AVM PR Check
         run: |
@@ -99,10 +99,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 #v5.2.0
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
       - name: Run Terraform unit tests
         run: |
@@ -131,10 +131,10 @@ jobs:
           df -h
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 #v5.2.0
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
       - name: Run Terraform integration tests
         run: |
@@ -168,7 +168,7 @@ jobs:
       examples: ${{ steps.getexamples.outputs.examples }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
       - name: Build example matrix and assign subscriptions
         id: getexamples
         run: |
@@ -207,7 +207,7 @@ jobs:
       setup_exists: ${{ steps.check-setup.outputs.setup_exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
       - name: Check if examples/setup.sh exists
         id: check-setup
         run: |
@@ -226,7 +226,7 @@ jobs:
     needs: [ checksetup, subscriptions ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
       - name: Run global setup script
         run: |
@@ -260,9 +260,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Set up Docker
-        uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d #v5.0.0
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 #v5.2.0
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
       - name: Deploy and validate example
         shell: bash
@@ -301,7 +301,7 @@ jobs:
       teardown_exists: ${{ steps.check-teardown.outputs.teardown_exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
       - name: Check if examples/teardown.sh exists
         id: check-teardown
         run: |
@@ -320,7 +320,7 @@ jobs:
     needs: [checkteardown, subscriptions]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
       - name: Run global teardown script
         run: |

--- a/.github/workflows/pre-commit-cron.yml
+++ b/.github/workflows/pre-commit-cron.yml
@@ -37,7 +37,7 @@ jobs:
       matrixParallel: ${{ steps.matrix.outputs.matrixParallel }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Generate Matrix
         uses: ./.github/actions/avm-repos
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check.outputs.continue
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ matrix.repoFullName }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/tf-repo-data-sync.yml
+++ b/.github/workflows/tf-repo-data-sync.yml
@@ -22,11 +22,11 @@ jobs:
 
     steps:
       - name: Checkout Bootstrap Modules
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}

--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Generate Matrix
         uses: ./.github/actions/avm-repos
@@ -66,17 +66,17 @@ jobs:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: latest
           terraform_wrapper: false
 
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}

--- a/.github/workflows/unlock-state-blobs.yml
+++ b/.github/workflows/unlock-state-blobs.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Azure Login (OIDC)
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}

--- a/.github/workflows/validate-extensions.yml
+++ b/.github/workflows/validate-extensions.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Validate extensions
         run: ./scripts/validate-vscode-extensions.sh

--- a/managed-files/root/.github/workflows/codeql.yml
+++ b/managed-files/root/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/tf-repo-mgmt/repository-config/deprecated-files.json
+++ b/tf-repo-mgmt/repository-config/deprecated-files.json
@@ -12,6 +12,7 @@
     ".github/workflows/e2e.yml",
     ".github/workflows/grept_cronjob.yml",
     ".github/workflows/linting.yml",
+    ".github/workflows/test-examples-template.yml",
     ".github/workflows/version-check.yml",
     ".vscode/mcp.json",
     "avm.config.json",

--- a/tf-repo-mgmt/repository_sync/modules/github/github.dependabot_secrets.tf
+++ b/tf-repo-mgmt/repository_sync/modules/github/github.dependabot_secrets.tf
@@ -1,0 +1,26 @@
+# Mirror of the repository-scope Actions secrets defined in
+# `github.actions_secrets.tf` as Dependabot secrets. Dependabot does not
+# share the Actions secret namespace, so any value Dependabot needs (e.g.
+# for authenticating to private registries via `dependabot.yml`) must be
+# duplicated here. Values are sourced from the same variables to keep
+# Actions and Dependabot in lockstep.
+resource "github_dependabot_secret" "arm_tenant_id" {
+  count           = var.repository_creation_mode_enabled ? 0 : 1
+  repository      = github_repository.this.name
+  secret_name     = "ARM_TENANT_ID"
+  plaintext_value = var.arm_tenant_id
+}
+
+resource "github_dependabot_secret" "arm_client_id" {
+  count           = var.repository_creation_mode_enabled ? 0 : 1
+  repository      = github_repository.this.name
+  secret_name     = "ARM_CLIENT_ID"
+  plaintext_value = var.arm_client_id
+}
+
+resource "github_dependabot_secret" "test_subscription_ids" {
+  count           = var.repository_creation_mode_enabled ? 0 : 1
+  repository      = github_repository.this.name
+  secret_name     = "TEST_SUBSCRIPTION_IDS"
+  plaintext_value = jsonencode(var.test_subscription_ids)
+}


### PR DESCRIPTION
Follow-up to #490.

## Changes

### Deprecated files
- Add `.github/workflows/test-examples-template.yml` to `tf-repo-mgmt/repository-config/deprecated-files.json` so it is removed from downstream AVM repos by the sync.

### GitHub Actions version bumps (all SHA-pinned with `# vX.Y.Z` comment)
- `actions/checkout` v6.0.2 -> v6.0.3 (also fixes a stale v4.2.2 reference in `validate-extensions.yml`)
- `actions/create-github-app-token` v3.1.1 -> v3.2.0
- `docker/login-action` v4.1.0 -> v4.2.0
- `docker/setup-qemu-action` v4.0.0 -> v4.1.0
- `docker/setup-buildx-action` v4.0.0 -> v4.1.0
- `docker/build-push-action` v7.1.0 -> v7.2.0
- `docker/metadata-action` v6.0.0 -> v6.1.0
- `docker/setup-docker-action` v5.0.0 -> v5.2.0
- `azure/login` v2.3.0 -> v3.0.0 (major bump; OIDC `client-id`/`tenant-id`/`subscription-id` usage remains compatible)
- `hashicorp/setup-terraform` v4.0.0 -> v4.0.1

`github/codeql-action` was left at v4.36.2 — its `releases/latest` returns a CodeQL bundle tag rather than an action-version tag, so it was not auto-bumped.