### PR TITLE
chore: metadata fixes

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -26,7 +26,6 @@ avm-ptn-azure-local-migrate,,,Azure Local Azure Migrate Project,saifaldinali,Sai
 avm-ptn-azureimagebuilder,,,Azure Image Builder,,ethanjenkins1,Ethan Jenkins MSFT,,,false
 avm-ptn-azuremonitorwindowsagent,,,Azure Monitor Windows Agent,,xhy8759,Hangyu Xu,,,false
 avm-ptn-bcdr-vm-replication,,,"The avm-ptn-bcdr-vm-replication module is designed to simplify the deployment and configuration of Virtual Machine replication using Azure Site Recovery Services (ASR) within Azure. It abstracts the complexity involved in setting up a disaster recovery scenario by managing all necessary resources to replicate a VM from one Azure region to another, ensuring that in case of a regional outage, your VM can be quickly recovered in the secondary location.",,ns-github-design,Nasreen Sarah,,,false
-avm-ptn-bcdr-vm-replication,,,Azure Site Recovery VM Replication,,FreddyAyala,Freddy Ayala,,,false
 avm-ptn-cicd-agents-and-runners,,,CI CD Agents and Runners,,jaredfholgate,Jared Holgate,,,false
 avm-ptn-cicd-bootstrap,,,CI CD bootstrap,,luke-taylor,Luke Taylor,,,false
 avm-ptn-cloudshell-vnet,,,Cloud Shell with vNET Integration,"CloudShell VNet, Cloud Shell VNET, Cloud Shell in Virtual Network",travishankins,Travis Hankins,,,false
@@ -72,7 +71,7 @@ avm-res-azurestackhci-virtualmachineinstance,Microsoft.AzureStackHCI,virtualMach
 avm-res-batch-batchaccount,Microsoft.Batch,batchAccounts,Batch Account,,ethanjenkins1,Ethan Jenkins,,,false
 avm-res-botservice-botservice,Microsoft.BotService,botServices,Bot Service,,salujamanish,Manish Saluja,,,false
 avm-res-cache-redis,Microsoft.Cache,Redis,Redis Cache,,jchancellor-ms,Jon Chancellor,,,false
-avm-res-cache-redis-enterprise,Microsoft.Cache,redisEnterprise,Redis Cached Enterprise,,Ankur1106,Ankur Sharma (HK),,,false
+avm-res-cache-redisenterprise,Microsoft.Cache,redisEnterprise,Redis Cached Enterprise,,Ankur1106,Ankur Sharma (HK),,,false
 avm-res-cdn-profile,Microsoft.Cdn,profiles,CDN Profile,,Poven795909,Poornima Venkataramanan,didayal-msft,Divyadeep Dayal,false
 avm-res-certificateregistration-certificateorder,Microsoft.CertificateRegistration,certificateOrders,Certificate Order,,lonegunmanb,Zijie He,,,false
 avm-res-cognitiveservices-account,Microsoft.CognitiveServices,accounts,Cognitive Service,,lonegunmanb,Zijie He,,,false


### PR DESCRIPTION
This pull request updates the `meta-data.csv` file to correct and clean up metadata entries for Azure resource and project repositories. The main changes focus on removing duplicate or outdated entries and fixing naming inconsistencies.

Repository metadata cleanup and correction:

* Removed a duplicate or outdated entry for `avm-ptn-bcdr-vm-replication`, ensuring only the correct, detailed description remains.
* Renamed the resource identifier for Redis Enterprise from `avm-res-cache-redis-enterprise` to `avm-res-cache-redisenterprise` to match naming conventions and maintain consistency.