### PR TITLE
chore: shorten bcdr display name and enforce 250-char limit in New-Repository

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -25,7 +25,7 @@ avm-ptn-azure-ipam,,,IPAM,IP Address Management,pagyP,Paul Paginton,,,false
 avm-ptn-azure-local-migrate,,,Azure Local Azure Migrate Project,saifaldinali,Saif Al-Din Ali,seswar,SathishKumar Eswaran,,false
 avm-ptn-azureimagebuilder,,,Azure Image Builder,,ethanjenkins1,Ethan Jenkins MSFT,,,false
 avm-ptn-azuremonitorwindowsagent,,,Azure Monitor Windows Agent,,xhy8759,Hangyu Xu,,,false
-avm-ptn-bcdr-vm-replication,,,"The avm-ptn-bcdr-vm-replication module is designed to simplify the deployment and configuration of Virtual Machine replication using Azure Site Recovery Services (ASR) within Azure. It abstracts the complexity involved in setting up a disaster recovery scenario by managing all necessary resources to replicate a VM from one Azure region to another, ensuring that in case of a regional outage, your VM can be quickly recovered in the secondary location.",,ns-github-design,Nasreen Sarah,,,false
+avm-ptn-bcdr-vm-replication,,,BCDR VM Replication,,ns-github-design,Nasreen Sarah,,,false
 avm-ptn-cicd-agents-and-runners,,,CI CD Agents and Runners,,jaredfholgate,Jared Holgate,,,false
 avm-ptn-cicd-bootstrap,,,CI CD bootstrap,,luke-taylor,Luke Taylor,,,false
 avm-ptn-cloudshell-vnet,,,Cloud Shell with vNET Integration,"CloudShell VNet, Cloud Shell VNET, Cloud Shell in Virtual Network",travishankins,Travis Hankins,,,false

--- a/tf-repo-mgmt/scripts/New-Repository.ps1
+++ b/tf-repo-mgmt/scripts/New-Repository.ps1
@@ -40,6 +40,11 @@ if($moduleDisplayName -eq "") {
   return
 }
 
+if($moduleDisplayName.Length -ge 250) {
+  Write-Error "Module display name must be under 250 characters (was $($moduleDisplayName.Length)). Keep it short, like 'Azure Image Builder' or 'BCDR VM Replication'." -Category InvalidArgument
+  return
+}
+
 if($moduleName.StartsWith("avm-res")) {
   if($resourceProviderNamespace -eq "") {
     Write-Error "Resource provider namespace must be provided for resource modules." -Category InvalidArgument


### PR DESCRIPTION
## What
Two small data-quality fixes for the repository-metadata pipeline.

### 1. `tf-repo-mgmt/repository-meta-data/meta-data.csv`
Replace the 461-character `avm-ptn-bcdr-vm-replication` description with the short `BCDR VM Replication` display name, matching the convention used by neighbouring rows (`Azure Image Builder`, `Azure Monitor Windows Agent`, `Azure Verified Module Test`).

### 2. `tf-repo-mgmt/scripts/New-Repository.ps1`
Add an upstream guardrail so the same mistake cannot land again: reject `-moduleDisplayName` values of 250+ characters before any fork / CSV append / PR work, with an error pointing at the short-name convention.

``powershell
if($moduleDisplayName.Length -ge 250) {
  Write-Error "Module display name must be under 250 characters (was $($moduleDisplayName.Length)). Keep it short, like 'Azure Image Builder' or 'BCDR VM Replication'." -Category InvalidArgument
  return
}
``

## Why
The CSV row is the source of truth for repo metadata that downstream tooling renders into READMEs, descriptions, and other places where a 461-character sentence is inappropriate. Catching it at the script entry point prevents recurrence.

## Test
- `moduleDisplayName.Length` is evaluated immediately after the existing empty-string check, so the failure happens before any side effects.
- CSV remains CRLF-encoded as required by `.gitattributes`.