### PR TITLE
feat(mapotf): handle ephemeral attribute for variables and outputs

### DIFF
--- a/mapotf-configs/pre-commit/order_module_attrs.mptf.hcl
+++ b/mapotf-configs/pre-commit/order_module_attrs.mptf.hcl
@@ -1,15 +1,12 @@
 # Order every module call.
 #
-#   head : meta-arguments (source / version / providers / count / for_each)
-#          — order matches avmfix's `headMetaArgPriorities` (lonegunmanb/avmfix
-#          pkg/argument.go): tier "" (source, version, providers) first in
-#          authored order, then count (priority "1"), then for_each (priority "2").
+#   head : meta-arguments — source, version and providers first (in authored
+#          order), then count, then for_each.
 #   body : required inputs (alpha) → optional inputs (alpha) — discovered via
 #          `data "module_source"` which loads the target module with
 #          `terraform-config-inspect`. Local sources (`./`, `../`, absolute paths)
 #          and registry/git/http sources are both supported by mapotf >= v0.1.4.
-#          Each group is wrapped in `sort()` to match avmfix's `SortByName()`
-#          (lonegunmanb/avmfix pkg/module_block.go) — mapotf v0.1.4 returns
+#          Each group is wrapped in `sort()` because mapotf v0.1.4 returns
 #          `required_variables` / `optional_variables` in source-declaration
 #          order, not alphabetical.
 #   foot : depends_on

--- a/mapotf-configs/pre-commit/sort_outputs.mptf.hcl
+++ b/mapotf-configs/pre-commit/sort_outputs.mptf.hcl
@@ -4,8 +4,7 @@ locals {
   outs = data.output.for_sort.result
 
   # Each output's target file: stay in its current file if that file already
-  # matches `*outputs*.tf`; otherwise route to `outputs.tf`. Mirrors avmfix's
-  # `outputsFileRegex` (lonegunmanb/avmfix pkg/hcl_file.go) which preserves
+  # matches `*outputs*.tf`; otherwise route to `outputs.tf`. This preserves
   # multi-file output layouts while consolidating strays.
   outs_with_tf = {
     for n, v in local.outs : n => {
@@ -20,25 +19,32 @@ locals {
 
   out_target_files = distinct([for n, vf in local.outs_with_tf : vf.target_file])
 
-  # Per-target-file ordered list (pure alphabetical, matches avmfix `SortByName()`).
+  # Per-target-file ordered list (pure alphabetical).
   ordered_outs_by_file = {
     for f in local.out_target_files : f => sort([for n, vf in local.outs_with_tf : n if vf.target_file == f])
   }
 }
 
-# Sort every output's body alphabetically — matches avmfix's `b.Attributes.SortByName()`
-# (lonegunmanb/avmfix pkg/outputs.go). No fixed head/foot list: all known output attrs
-# (`description`, `sensitive`, `value`, `depends_on`, `precondition`) sort by name.
+# Sort every output's body alphabetically. No fixed head/foot list: all known output attrs
+# (`description`, `sensitive`, `ephemeral`, `value`, `depends_on`, `precondition`) sort by name.
 transform "reorder_attributes" "output_attrs" {
   for_each                 = local.outs
   target_block_address     = "output.${each.key}"
   sort_body_alphabetically = true
 }
 
+# Drop redundant sensitive = false (the language default).
 transform "remove_block_element" "drop_output_sensitive_false" {
   for_each             = { for n, v in local.outs : n => v if try(v.sensitive, null) == false }
   target_block_address = "output.${each.key}"
   paths                = ["sensitive"]
+}
+
+# Drop redundant ephemeral = false (the language default).
+transform "remove_block_element" "drop_output_ephemeral_false" {
+  for_each             = { for n, v in local.outs : n => v if try(v.ephemeral, null) == false }
+  target_block_address = "output.${each.key}"
+  paths                = ["ephemeral"]
 }
 
 # Per-file sort. One transform per file that currently holds at least one output

--- a/mapotf-configs/pre-commit/sort_variables.mptf.hcl
+++ b/mapotf-configs/pre-commit/sort_variables.mptf.hcl
@@ -5,8 +5,7 @@ locals {
 
   # Each variable's target file: stay in its current file if that file already
   # matches the canonical `*variables*.tf` pattern; otherwise route to
-  # `variables.tf`. Mirrors avmfix's `variablesFileRegex` (lonegunmanb/avmfix
-  # pkg/hcl_file.go) which preserves multi-file layouts like
+  # `variables.tf`. This preserves multi-file layouts like
   # `variables.diagnostics.tf`, `variables.share.tf`, etc. while still
   # consolidating stray variables that live in `main.tf` or similar.
   vars_with_tf = {
@@ -31,13 +30,13 @@ locals {
   }
 }
 
-# Re-order attributes inside every variable block: type, default, description, nullable, sensitive.
+# Re-order attributes inside every variable block: type, default, description, nullable, sensitive, ephemeral.
 # Anything else (validation, etc.) stays as a nested element handled by mapotf's reorder_attributes
 # nested-block semantics.
 transform "reorder_attributes" "var_attrs" {
   for_each                 = local.vars
   target_block_address     = "variable.${each.key}"
-  head_attributes          = ["type", "default", "description", "nullable", "sensitive"]
+  head_attributes          = ["type", "default", "description", "nullable", "sensitive", "ephemeral"]
   sort_body_alphabetically = false
 }
 
@@ -53,6 +52,13 @@ transform "remove_block_element" "drop_sensitive_false" {
   for_each             = { for n, v in local.vars : n => v if try(v.sensitive, null) == false }
   target_block_address = "variable.${each.key}"
   paths                = ["sensitive"]
+}
+
+# Drop redundant ephemeral = false (the language default).
+transform "remove_block_element" "drop_ephemeral_false" {
+  for_each             = { for n, v in local.vars : n => v if try(v.ephemeral, null) == false }
+  target_block_address = "variable.${each.key}"
+  paths                = ["ephemeral"]
 }
 
 # Per-file sort. One transform per file that currently holds at least one variable


### PR DESCRIPTION
## Summary

Adds first-class handling for the Terraform 1.10+ `ephemeral` attribute in the mapotf pre-commit configs, and removes lingering `avmfix` references from comments.

## Changes

**Variables** (`sort_variables.mptf.hcl`)
- Add `ephemeral` to the variable `head_attributes` ordering, grouped last (after `sensitive`), so it sits with the other scalar attributes instead of being pushed into the body block separated by a blank line.
- Strip redundant `ephemeral = false` (the language default), matching the existing `nullable = true` / `sensitive = false` strips.

**Outputs** (`sort_outputs.mptf.hcl`)
- Strip redundant `ephemeral = false` for consistency with variables (output blocks also support `ephemeral`). Body ordering is already alphabetical, so `ephemeral` sorts into place automatically.
- Note `ephemeral` in the body-sort comment's list of known output attributes.
- Add a matching comment to the existing `sensitive = false` strip so both files read consistently.

**Comment cleanup** (all three files)
- Remove `avmfix` / `lonegunmanb` references from comments (internal Go function/file names), retaining the helpful rationale that explains what each transform does.

## Notes

- This intentionally diverges from `avmfix`, which currently has no `ephemeral` ordering. The chosen placement (last in the group) follows the maintainer preference rather than `avmfix`'s `variableAttributePriorities`.
- Example of current behavior: see [Azure/terraform-azurerm-avm-res-containerservice-managedcluster#223](https://github.com/Azure/terraform-azurerm-avm-res-containerservice-managedcluster/pull/223).
