### PR TITLE
chore: add avm-res-insights-privatelinkscope metadata

### DIFF
--- a/tf-repo-mgmt/repository-meta-data/meta-data.csv
+++ b/tf-repo-mgmt/repository-meta-data/meta-data.csv
@@ -130,6 +130,7 @@ avm-res-insights-datacollectionendpoint,Microsoft.Insights,dataCollectionEndpoin
 avm-res-insights-datacollectionrule,Microsoft.Insights,dataCollectionRules,Data Collection Rule,,sharmilamusunuru,Sharmila Musunuru,,,false
 avm-res-insights-logprofile,Microsoft.Insights,logProfiles,Log profile,,sharmilamusunuru,Sharmila Musunuru,,,false
 avm-res-insights-metricalert,Microsoft.Insights,metricAlerts,Insights Metric Alert,,arjenhuitema,Arjen Huitema,Brunoga-MS,Bruno Gabrielli,false
+avm-res-insights-privatelinkscope,Microsoft.Insights,privateLinkScopes,avm-res-insights-privatelinkscope,,Vasikaran6,Vasikaran Veerappan,,,false
 avm-res-insights-privatelinkscope,Microsoft.Insights,privateLinkScopes,Managed Services Registration Definition,,sharmilamusunuru,Sharmila Musunuru,,,false
 avm-res-insights-scheduledqueryrule,Microsoft.Insights,scheduledQueryRules,Scheduled Query Rule,,,,,,false
 avm-res-iotoperations-instance,Microsoft.IoTOperations,instances,IOT Operations Instance,,agreaves-ms,Allen Greaves,,,false


### PR DESCRIPTION
This PR adds metadata for the avm-res-insights-privatelinkscope module.