### PR TITLE
chore: add more repos to canary repo group for testing issue triage

### DIFF
--- a/tf-repo-mgmt/repository-config/config.json
+++ b/tf-repo-mgmt/repository-config/config.json
@@ -23,7 +23,7 @@
         "avm-res-documentdb-mongocluster",
         "avm-res-compute-disk",
         "avm-res-dbformysql-flexibleserver",
-        "avm-res-azurestackhci-virtualmachineinstance"
+        "avm-res-cdn-profile"
       ],
       "topics": [
         "canary"

--- a/tf-repo-mgmt/repository-config/config.json
+++ b/tf-repo-mgmt/repository-config/config.json
@@ -16,7 +16,14 @@
       "managedFilesAdditional": "canary",
       "repositories": [
         "avm-ptn-example-repo",
-        "avm-res-devopsinfrastructure-pool"
+        "avm-res-devopsinfrastructure-pool",
+        "avm-res-network-virtualnetwork",
+        "avm-res-documentdb-databaseaccount",
+        "avm-res-app-managedenvironment",
+        "avm-res-documentdb-mongocluster",
+        "avm-res-compute-disk",
+        "avm-res-dbformysql-flexibleserver",
+        "avm-res-azurestackhci-virtualmachineinstance"
       ],
       "topics": [
         "canary"


### PR DESCRIPTION
Add repos for testing the GitHub agentic issue triage:
- [avm-res-network-virtualnetwork](https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork)
- [avm-res-documentdb-databaseaccount](https://github.com/Azure/terraform-azurerm-avm-res-documentdb-databaseaccount)
- [avm-res-app-managedenvironment](https://github.com/Azure/terraform-azurerm-avm-res-app-managedenvironment)
- [avm-res-documentdb-mongocluster](https://github.com/Azure/terraform-azurerm-avm-res-documentdb-mongocluster)
- [avm-res-compute-disk](https://github.com/Azure/terraform-azurerm-avm-res-compute-disk)
- [avm-res-dbformysql-flexibleserver](https://github.com/Azure/terraform-azurerm-avm-res-dbformysql-flexibleserver)
- [avm-res-cdn-profile](https://github.com/Azure/terraform-azurerm-avm-res-cdn-profile)