### PR TITLE
Harden Terraform porch cleanup (all configs) + add mocked example unit tests

### DIFF
--- a/porch-configs/pr-check.porch.yaml
+++ b/porch-configs/pr-check.porch.yaml
@@ -54,10 +54,10 @@ commands:
           - type: shell
             name: clean terraform
             command_line: |
-              echo $(pwd) && \
-              find . -type d -name .terraform | xargs -n1 rm -rf && \
-              find . -type f -name .terraform.lock.hcl | xargs -n1 rm -f && \
-              find . -type f -name *.tfstate* | xargs -n1 rm -f
+              echo "$(pwd)"
+              find . -type d -name '.terraform' -prune -exec rm -rf {} +
+              find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
+              find . -type f -name '*.tfstate*' -exec rm -f {} +
 
           # tflint
           - type: serial
@@ -227,10 +227,10 @@ commands:
       - type: shell
         name: Clean Terraform
         command_line: |
-          echo $(pwd) && \
-          find . -type d -name .terraform | xargs -n1 rm -rf && \
-          find . -type f -name .terraform.lock.hcl | xargs -n1 rm -f && \
-          find . -type f -name *.tfstate* | xargs -n1 rm -f
+          echo "$(pwd)"
+          find . -type d -name '.terraform' -prune -exec rm -rf {} +
+          find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
+          find . -type f -name '*.tfstate*' -exec rm -f {} +
 
       - type: foreachdirectory
         name: well architected

--- a/porch-configs/terraform-test.porch.yaml
+++ b/porch-configs/terraform-test.porch.yaml
@@ -34,10 +34,10 @@ command_groups:
         - type: shell
           name: Clean Terraform
           command_line: |
-            echo $(pwd) && \
-            find . -type d -name .terraform | xargs -n1 rm -rf && \
-            find . -type f -name .terraform.lock.hcl | xargs -n1 rm -f && \
-            find . -type f -name *.tfstate* | xargs -n1 rm -f
+            echo "$(pwd)"
+            find . -type d -name '.terraform' -prune -exec rm -rf {} +
+            find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
+            find . -type f -name '*.tfstate*' -exec rm -f {} +
 
         - type: shell
           name: Check and Run setup.sh
@@ -70,7 +70,19 @@ command_groups:
         - type: shell
           name: Clean up
           command_line: |
-            rm -fr $(pwd)
+            workdir="$(pwd)"
+            cd /
+            case "$workdir" in
+              /tmp/*|/var/tmp/*)
+                rm -rf "$workdir"
+                ;;
+              *)
+                echo "Refusing to remove non-temp directory: $workdir" 1>&2
+                find "$workdir" -type d -name '.terraform' -prune -exec rm -rf {} + 2>/dev/null || true
+                find "$workdir" -type f -name '.terraform.lock.hcl' -exec rm -f {} + 2>/dev/null || true
+                find "$workdir" -type f -name '*.tfstate*' -exec rm -f {} + 2>/dev/null || true
+                ;;
+            esac
           runs_on_condition: always
 
 commands:

--- a/porch-configs/test-examples.porch.yaml
+++ b/porch-configs/test-examples.porch.yaml
@@ -16,9 +16,9 @@ commands:
   - type: shell
     name: Clean Terraform
     command_line: |
-      find . -type d -name .terraform | xargs -n1 rm -rf && \
-      find . -type f -name .terraform.lock.hcl | xargs -n1 rm -f && \
-      find . -type f -name *.tfstate* | xargs -n1 rm -f
+      find . -type d -name '.terraform' -prune -exec rm -rf {} +
+      find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
+      find . -type f -name '*.tfstate*' -exec rm -f {} +
 
   - type: foreachdirectory
     name: for each example clean up if not matching AVM_EXAMPLE
@@ -162,5 +162,17 @@ commands:
   - type: shell
     name: Clean up
     command_line: |
-      rm -fr $(pwd)
+      workdir="$(pwd)"
+      cd /
+      case "$workdir" in
+        /tmp/*|/var/tmp/*)
+          rm -rf "$workdir"
+          ;;
+        *)
+          echo "Refusing to remove non-temp directory: $workdir" 1>&2
+          find "$workdir" -type d -name '.terraform' -prune -exec rm -rf {} + 2>/dev/null || true
+          find "$workdir" -type f -name '.terraform.lock.hcl' -exec rm -f {} + 2>/dev/null || true
+          find "$workdir" -type f -name '*.tfstate*' -exec rm -f {} + 2>/dev/null || true
+          ;;
+      esac
     runs_on_condition: always

--- a/tests/terraform-azure-avm-res-mock/examples/default/README.md
+++ b/tests/terraform-azure-avm-res-mock/examples/default/README.md
@@ -6,7 +6,8 @@
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }
 ```
 
@@ -28,11 +29,23 @@ No required inputs.
 
 ## Optional Inputs
 
-No optional inputs.
+The following input variables are optional (have default values):
+
+### <a name="input_create_example_resources"></a> [create\_example\_resources](#input\_create\_example\_resources)
+
+Description: Whether to create the example resources in the wrapped module.
+
+Type: `bool`
+
+Default: `false`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The ID of the resource created by the wrapped module.
 
 ## Modules
 

--- a/tests/terraform-azure-avm-res-mock/examples/default/main.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/default/main.tf
@@ -1,5 +1,6 @@
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }

--- a/tests/terraform-azure-avm-res-mock/examples/default/outputs.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/default/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The ID of the resource created by the wrapped module."
+  value       = module.test.resource_id
+}

--- a/tests/terraform-azure-avm-res-mock/examples/default/variables.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/default/variables.tf
@@ -1,0 +1,6 @@
+variable "create_example_resources" {
+  type        = bool
+  default     = false
+  description = "Whether to create the example resources in the wrapped module."
+  nullable    = false
+}

--- a/tests/terraform-azure-avm-res-mock/examples/ignored_example/README.md
+++ b/tests/terraform-azure-avm-res-mock/examples/ignored_example/README.md
@@ -6,7 +6,8 @@
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }
 ```
 
@@ -28,11 +29,23 @@ No required inputs.
 
 ## Optional Inputs
 
-No optional inputs.
+The following input variables are optional (have default values):
+
+### <a name="input_create_example_resources"></a> [create\_example\_resources](#input\_create\_example\_resources)
+
+Description: Whether to create the example resources in the wrapped module.
+
+Type: `bool`
+
+Default: `false`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The ID of the resource created by the wrapped module.
 
 ## Modules
 

--- a/tests/terraform-azure-avm-res-mock/examples/ignored_example/main.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/ignored_example/main.tf
@@ -1,5 +1,6 @@
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }

--- a/tests/terraform-azure-avm-res-mock/examples/ignored_example/outputs.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/ignored_example/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The ID of the resource created by the wrapped module."
+  value       = module.test.resource_id
+}

--- a/tests/terraform-azure-avm-res-mock/examples/ignored_example/variables.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/ignored_example/variables.tf
@@ -1,0 +1,6 @@
+variable "create_example_resources" {
+  type        = bool
+  default     = false
+  description = "Whether to create the example resources in the wrapped module."
+  nullable    = false
+}

--- a/tests/terraform-azure-avm-res-mock/examples/second_example/README.md
+++ b/tests/terraform-azure-avm-res-mock/examples/second_example/README.md
@@ -6,7 +6,8 @@
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }
 ```
 
@@ -28,11 +29,23 @@ No required inputs.
 
 ## Optional Inputs
 
-No optional inputs.
+The following input variables are optional (have default values):
+
+### <a name="input_create_example_resources"></a> [create\_example\_resources](#input\_create\_example\_resources)
+
+Description: Whether to create the example resources in the wrapped module.
+
+Type: `bool`
+
+Default: `false`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The ID of the resource created by the wrapped module.
 
 ## Modules
 

--- a/tests/terraform-azure-avm-res-mock/examples/second_example/main.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/second_example/main.tf
@@ -1,5 +1,6 @@
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }

--- a/tests/terraform-azure-avm-res-mock/examples/second_example/outputs.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/second_example/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The ID of the resource created by the wrapped module."
+  value       = module.test.resource_id
+}

--- a/tests/terraform-azure-avm-res-mock/examples/second_example/variables.tf
+++ b/tests/terraform-azure-avm-res-mock/examples/second_example/variables.tf
@@ -1,0 +1,6 @@
+variable "create_example_resources" {
+  type        = bool
+  default     = false
+  description = "Whether to create the example resources in the wrapped module."
+  nullable    = false
+}

--- a/tests/terraform-azure-avm-res-mock/tests/unit/examples.tftest.hcl
+++ b/tests/terraform-azure-avm-res-mock/tests/unit/examples.tftest.hcl
@@ -1,0 +1,46 @@
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  create_example_resources = true
+}
+
+run "default" {
+  command = apply
+
+  module {
+    source = "./examples/default"
+  }
+
+  assert {
+    condition     = output.resource_id != null
+    error_message = "The default example should produce a non-null resource_id when create_example_resources is true."
+  }
+}
+
+run "second_example" {
+  command = apply
+
+  module {
+    source = "./examples/second_example"
+  }
+
+  assert {
+    condition     = output.resource_id != null
+    error_message = "The second_example example should produce a non-null resource_id when create_example_resources is true."
+  }
+}
+
+run "ignored_example" {
+  command = apply
+
+  module {
+    source = "./examples/ignored_example"
+  }
+
+  assert {
+    condition     = output.resource_id != null
+    error_message = "The ignored_example example should produce a non-null resource_id when create_example_resources is true."
+  }
+}

--- a/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/README.md
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/README.md
@@ -10,7 +10,8 @@ provider "azurerm" {
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }
 ```
 
@@ -34,11 +35,23 @@ No required inputs.
 
 ## Optional Inputs
 
-No optional inputs.
+The following input variables are optional (have default values):
+
+### <a name="input_create_example_resources"></a> [create\_example\_resources](#input\_create\_example\_resources)
+
+Description: Whether to create the example resources in the wrapped module.
+
+Type: `bool`
+
+Default: `false`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The ID of the resource created by the wrapped module.
 
 ## Modules
 

--- a/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/main.tf
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/main.tf
@@ -5,5 +5,6 @@ provider "azurerm" {
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }

--- a/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/outputs.tf
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The ID of the resource created by the wrapped module."
+  value       = module.test.resource_id
+}

--- a/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/variables.tf
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default-ignore/variables.tf
@@ -1,0 +1,6 @@
+variable "create_example_resources" {
+  type        = bool
+  default     = false
+  description = "Whether to create the example resources in the wrapped module."
+  nullable    = false
+}

--- a/tests/terraform-azurerm-avm-res-mock/examples/default/README.md
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default/README.md
@@ -10,7 +10,8 @@ provider "azurerm" {
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }
 ```
 
@@ -34,11 +35,23 @@ No required inputs.
 
 ## Optional Inputs
 
-No optional inputs.
+The following input variables are optional (have default values):
+
+### <a name="input_create_example_resources"></a> [create\_example\_resources](#input\_create\_example\_resources)
+
+Description: Whether to create the example resources in the wrapped module.
+
+Type: `bool`
+
+Default: `false`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The ID of the resource created by the wrapped module.
 
 ## Modules
 

--- a/tests/terraform-azurerm-avm-res-mock/examples/default/main.tf
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default/main.tf
@@ -5,5 +5,6 @@ provider "azurerm" {
 module "test" {
   source = "../../"
 
-  location = "westus3"
+  location                 = "westus3"
+  create_example_resources = var.create_example_resources
 }

--- a/tests/terraform-azurerm-avm-res-mock/examples/default/outputs.tf
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_id" {
+  description = "The ID of the resource created by the wrapped module."
+  value       = module.test.resource_id
+}

--- a/tests/terraform-azurerm-avm-res-mock/examples/default/variables.tf
+++ b/tests/terraform-azurerm-avm-res-mock/examples/default/variables.tf
@@ -1,0 +1,6 @@
+variable "create_example_resources" {
+  type        = bool
+  default     = false
+  description = "Whether to create the example resources in the wrapped module."
+  nullable    = false
+}

--- a/tests/terraform-azurerm-avm-res-mock/tests/unit/examples.tftest.hcl
+++ b/tests/terraform-azurerm-avm-res-mock/tests/unit/examples.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  create_example_resources = true
+}
+
+run "default" {
+  command = apply
+
+  module {
+    source = "./examples/default"
+  }
+
+  assert {
+    condition     = output.resource_id != null
+    error_message = "The default example should produce a non-null resource_id when create_example_resources is true."
+  }
+}
+
+run "default_ignore" {
+  command = apply
+
+  module {
+    source = "./examples/default-ignore"
+  }
+
+  assert {
+    condition     = output.resource_id != null
+    error_message = "The default-ignore example should produce a non-null resource_id when create_example_resources is true."
+  }
+}


### PR DESCRIPTION
## Summary

The `terraform test` porch flow (`porch-configs/terraform-test.porch.yaml`) has two cleanup bugs that cause intermittent CI failures and can **delete the source working directory** in local/devcontainer runs. They combine into a failure cascade that surfaces as a confusing `Provider type mismatch` error (e.g. [terraform-azure-avm-ptn-alz-sub-vending run 29035887910](https://github.com/Azure/terraform-azure-avm-ptn-alz-sub-vending/actions/runs/29035887910/job/86180521130?pr=40)).

This PR fixes those bugs, extends the same hardening to the **sibling porch configs** that share the fragile cleanup pattern, and adds **mocked unit tests for every example** in the mock test modules.

## Root cause (cleanup bugs)

1. **`Clean up`** ran `rm -fr $(pwd)` with no guard. When the working directory is the source (`/src` in CI, or the real repo in a devcontainer — because `copycwdtotemp` did not change cwd for that flow), it either fails with `Permission denied` (leaving stale `.terraform` to accumulate) or **succeeds and deletes the real repository**.
2. **`Clean Terraform`** used a fragile `find … | xargs -n1 rm` chain joined with `&&`. GNU `xargs` runs `rm` once even with no input (exit non-zero), which short-circuits the `&&` chain and leaves a partially-cleaned `.terraform`.

On the next run, `copycwdtotemp` copies that stale/corrupt `.terraform` (whose `.terraform/modules/*/.git` repos contain absolute `/src` git alternates) into the temp workspace. `terraform init` then hits the corrupt module git state, the child modules never download, their `required_providers` become unreadable, and `azapi`/`modtm` default to the `hashicorp/*` namespace instead of `azure/*` → **`Provider type mismatch`**.

The `Provider type mismatch` is a **symptom, not the cause** — the module code is correct.

## Changes

### 1. Porch cleanup hardening

Applied to `porch-configs/terraform-test.porch.yaml`, and the same fixes extended to the sibling configs sharing the pattern:

- `porch-configs/pr-check.porch.yaml` (both `Clean Terraform` steps)
- `porch-configs/test-examples.porch.yaml` (`Clean Terraform` + guarded `Clean up`)

**`Clean Terraform`** — independent `find … -exec rm … {} +` commands (no `&&` chain, no `xargs` empty-input failure, quoted globs):

```
echo "$(pwd)"
find . -type d -name '.terraform' -prune -exec rm -rf {} +
find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
find . -type f -name '*.tfstate*' -exec rm -f {} +
```

**`Clean up`** — only `rm -rf` a genuine temp path; otherwise refuse and do a best-effort cleanup of Terraform artifacts only, so stale `.terraform` never accumulates and the source repo is never destroyed:

```
workdir="$(pwd)"
cd /
case "$workdir" in
  /tmp/*|/var/tmp/*)
    rm -rf "$workdir"
    ;;
  *)
    echo "Refusing to remove non-temp directory: $workdir" 1>&2
    find "$workdir" -type d -name '.terraform' -prune -exec rm -rf {} + 2>/dev/null || true
    find "$workdir" -type f -name '.terraform.lock.hcl' -exec rm -f {} + 2>/dev/null || true
    find "$workdir" -type f -name '*.tfstate*' -exec rm -f {} + 2>/dev/null || true
    ;;
esac
```

Integration tests need no separate change — `tf-test-integration` reuses `terraform-test.porch.yaml` (already covered here).

### 2. Mocked unit tests for every example

Each example in the mock test modules previously only wrapped the root module, exposed no outputs, and had no test coverage — so example regressions were only caught by the real-deploy `test-examples` flow. For every example (`terraform-azure-avm-res-mock`: default, second_example, ignored_example; `terraform-azurerm-avm-res-mock`: default, default-ignore):

- Forward a new `create_example_resources` variable (bool, default `false`) into the wrapped module, so real `test-examples` deploys stay resource-free while tests can opt in.
- Re-export `resource_id` via `outputs.tf` so the wrapped module's id is assertable.
- Add `tests/unit/examples.tftest.hcl` that applies each example under mock providers and asserts a non-null `resource_id`.
- Regenerated example READMEs for the new inputs/outputs.

## Verification

- YAML parses; per-file block-scalar indentation preserved; both scripts pass `bash -n`.
- Guard branch selection tested with `rm`/`find` stubbed: `/tmp/porch_*` and `/var/tmp/porch_*` → `rm -rf`; `/src` and `/workspaces/<repo>` → refuse + best-effort `.terraform` clean.
- `terraform test -test-directory ./tests/unit` passes for both mock modules (azure: 4 passed; azurerm: 3 passed), covering the new example tests plus the existing unit test.
- `terraform fmt -check -recursive` clean for both modules.

> Note: `avm pre-commit` could not be run on the Windows dev host; CI's pre-commit will confirm doc/format self-healing.

## Docs

The porch changes are internal CI/porch behavior (not user-facing documented behavior). Establishing "examples carry mocked unit tests" as a **convention** may warrant an Azure-Verified-Modules-Docs update if adopted broadly; flagging for maintainer consideration.