### PR TITLE
fix(porch): flatten terraform_tests command group to isolate each test branch

### DIFF
--- a/porch-configs/terraform-test.porch.yaml
+++ b/porch-configs/terraform-test.porch.yaml
@@ -24,66 +24,63 @@ command_groups:
           fi
         skip_exit_codes: [99]
 
-      - type: serial
-        name: Terraform test steps
-        commands:
-        - type: copycwdtotemp
-          name: Copy current working directory to temp
-          cwd: "."
+      - type: copycwdtotemp
+        name: Copy current working directory to temp
+        cwd: "."
 
-        - type: shell
-          name: Clean Terraform
-          command_line: |
-            echo "$(pwd)"
-            find . -type d -name '.terraform' -prune -exec rm -rf {} +
-            find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
-            find . -type f -name '*.tfstate*' -exec rm -f {} +
+      - type: shell
+        name: Clean Terraform
+        command_line: |
+          echo "$(pwd)"
+          find . -type d -name '.terraform' -prune -exec rm -rf {} +
+          find . -type f -name '.terraform.lock.hcl' -exec rm -f {} +
+          find . -type f -name '*.tfstate*' -exec rm -f {} +
 
-        - type: shell
-          name: Check and Run setup.sh
-          command_line: |
-            if [ -f ./tests/$AVM_TEST_TYPE/setup.sh ]; then
-              if [ ! -x ./tests/$AVM_TEST_TYPE/setup.sh ]; then
-                echo "Making setup.sh executable"
-                chmod +x ./tests/$AVM_TEST_TYPE/setup.sh
-              fi
-              echo "Running setup.sh"
-              ./tests/$AVM_TEST_TYPE/setup.sh
+      - type: shell
+        name: Check and Run setup.sh
+        command_line: |
+          if [ -f ./tests/$AVM_TEST_TYPE/setup.sh ]; then
+            if [ ! -x ./tests/$AVM_TEST_TYPE/setup.sh ]; then
+              echo "Making setup.sh executable"
+              chmod +x ./tests/$AVM_TEST_TYPE/setup.sh
             fi
+            echo "Running setup.sh"
+            ./tests/$AVM_TEST_TYPE/setup.sh
+          fi
 
-        - type: pwsh
-          name: Check and Run setup.ps1
-          script: |
-            if (Test-Path ./tests/$env:AVM_TEST_TYPE/setup.ps1) {
-              Write-Host "Running setup.ps1"
-              & ./tests/$env:AVM_TEST_TYPE/setup.ps1
-            }
+      - type: pwsh
+        name: Check and Run setup.ps1
+        script: |
+          if (Test-Path ./tests/$env:AVM_TEST_TYPE/setup.ps1) {
+            Write-Host "Running setup.ps1"
+            & ./tests/$env:AVM_TEST_TYPE/setup.ps1
+          }
 
-        - type: shell
-          name: "Terraform Init"
-          command_line: "terraform init -test-directory ./tests/$AVM_TEST_TYPE"
+      - type: shell
+        name: "Terraform Init"
+        command_line: "terraform init -test-directory ./tests/$AVM_TEST_TYPE"
 
-        - type: shell
-          name: "Terraform Test"
-          command_line: "terraform test -test-directory ./tests/$AVM_TEST_TYPE"
+      - type: shell
+        name: "Terraform Test"
+        command_line: "terraform test -test-directory ./tests/$AVM_TEST_TYPE"
 
-        - type: shell
-          name: Clean up
-          command_line: |
-            workdir="$(pwd)"
-            cd /
-            case "$workdir" in
-              /tmp/*|/var/tmp/*)
-                rm -rf "$workdir"
-                ;;
-              *)
-                echo "Refusing to remove non-temp directory: $workdir" 1>&2
-                find "$workdir" -type d -name '.terraform' -prune -exec rm -rf {} + 2>/dev/null || true
-                find "$workdir" -type f -name '.terraform.lock.hcl' -exec rm -f {} + 2>/dev/null || true
-                find "$workdir" -type f -name '*.tfstate*' -exec rm -f {} + 2>/dev/null || true
-                ;;
-            esac
-          runs_on_condition: always
+      - type: shell
+        name: Clean up
+        command_line: |
+          workdir="$(pwd)"
+          cd /
+          case "$workdir" in
+            /tmp/*|/var/tmp/*)
+              rm -rf "$workdir"
+              ;;
+            *)
+              echo "Refusing to remove non-temp directory: $workdir" 1>&2
+              find "$workdir" -type d -name '.terraform' -prune -exec rm -rf {} + 2>/dev/null || true
+              find "$workdir" -type f -name '.terraform.lock.hcl' -exec rm -f {} + 2>/dev/null || true
+              find "$workdir" -type f -name '*.tfstate*' -exec rm -f {} + 2>/dev/null || true
+              ;;
+          esac
+        runs_on_condition: always
 
 commands:
   - type: shell


### PR DESCRIPTION
## Why this is still failing after #517

#517 hardened the fragile cleanup steps (`xargs -n1 rm` → `-exec … +`, and guarded `rm -fr $(pwd)`). That was necessary but it was **not** the root cause of the `Provider type mismatch` cascade seen in consuming repos (e.g. `terraform-azure-avm-ptn-alz-sub-vending` PR #40). This PR fixes the actual cause.

## Root cause (a porch 0.2.6 behaviour)

The container already runs **porch 0.2.6** (confirmed via `porch --version` in the released `avm-latest` image), so a version bump is **not** the fix.

The bug is topological. In `terraform-test.porch.yaml`, `copycwdtotemp` lived inside a nested `serial "Terraform test steps"` that was the `command_group` of a `foreachdirectory` **item** branch. With that specific nesting, porch 0.2.6:

- **Bug A** — resolves `copycwdtotemp`'s `cwd: "."` against the porch **base** dir (`/src` in CI), not the inherited item dir (`modules/<name>`), so it copies the wrong directory.
- **Bug B** — does **not** propagate the copy's `newCwd` to the following sibling steps, so `Terraform Init` / `Terraform Test` run in the base dir, not the `/tmp` copy.

Net effect: every submodule branch ran terraform in the shared base dir and built the **root** module's children into `/src/.terraform`, racing the root branch that used the same path. The corrupted, half-downloaded modules then made `azapi` resolve to `hashicorp/azapi` instead of `Azure/azapi` → the confusing **`Provider type mismatch`** error. It's a symptom, not the cause.

The plain `serial "root module"` branch was unaffected (porch's existing cwd fixes handle plain serials), which is why the failure looked intermittent and submodule-specific.

## The fix

Flatten the nested serial: `copycwdtotemp` and the subsequent steps become **direct children** of the `terraform_tests` command group. Every branch (root + each submodule) now copies **its own** directory into an **isolated `/tmp` workspace** and tests the **correct** module. No more shared-`/src` collision.

## Verification (porch 0.2.6, against a fixture)

Ran the real modified config end-to-end in the released image:

- `[sub1]` (has tests) → isolated in its own `/tmp/porch_*`, `copycwdtotemp` runs at `modules/sub1`, tests its own module → **1 passed, 0 failed**
- `root` → isolated in a **separate** `/tmp/porch_*` → **1 passed, 0 failed**
- `[sub2]` (no tests) → `exit 99`, all steps skipped; guarded `Clean up` safely refuses the non-temp source dir
- **No `.terraform` written to the shared base** — the `/src` race is gone
- Skip propagation (`skip_exit_codes: [99]`) and the guarded `Clean up` (`runs_on_condition: always`) both preserved

Also confirmed the two sibling configs do **not** need this change:

- `pr-check.porch.yaml` — all `copycwdtotemp` are in `parallel → serial` or top-level serial branches (the patterns porch handles correctly); no `foreachdirectory` contains a nested copy.
- `test-examples.porch.yaml` — `copycwdtotemp` is top-level; a focused repro proved its `newCwd` **does** propagate to a later `foreachdirectory` sibling, so examples run isolated under `/tmp/.../examples/<item>`.

## Scope

Integration tests reuse `terraform-test.porch.yaml`, so they're covered by the same change. Consuming repos pull configs from `main` at run time, so the fix takes effect for all modules once merged. No docs change needed — porch is internal CI plumbing.