### PR TITLE
Centrally sync AVM Terraform issues & PRs into the "AVM All Up" project (with rate-limit look-back)

### DIFF
--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -29,10 +29,6 @@ on:
         description: 'Also add closed issues and closed/merged PRs to the project (heavy historical back-fill). Off by default.'
         default: false
         type: boolean
-      project_url:
-        description: 'The GitHub Project (ProjectV2) URL to add each repository''s issues and PRs to.'
-        default: 'https://github.com/orgs/Azure/projects/1011'
-        type: string
       project_lookback_days:
         description: 'Only add issues/PRs updated in the last N days (keeps runs under API rate limits). Use 0 to disable the look-back and sweep everything not already on the project (one-off initial back-fill).'
         default: '3'
@@ -43,6 +39,12 @@ on:
 permissions:
   id-token: write
   contents: read
+
+env:
+  # The GitHub Project (ProjectV2) that every AVM Terraform repo's issues and PRs
+  # are synced into ("AVM All Up"). A central, fixed target, so it lives here as a
+  # single workflow constant rather than a per-run input.
+  PROJECT_URL: 'https://github.com/orgs/Azure/projects/1011'
 
 defaults:
   run:
@@ -190,7 +192,7 @@ jobs:
 
           $planOnly = $false
           $includeClosed = $false
-          $projectUrl = "https://github.com/orgs/Azure/projects/1011"
+          $projectUrl = $env:PROJECT_URL
           # Default look-back: scheduled/dispatch-by-event runs only consider items
           # updated in the last 3 days, which keeps steady-state runs well under the
           # GitHub API rate limits. A manual dispatch can override this (0 = full
@@ -200,9 +202,6 @@ jobs:
           if ($triggerType -eq "workflow_dispatch") {
             $planOnly = "${{ inputs.plan_only }}".ToLower() -eq "true"
             $includeClosed = "${{ inputs.include_closed_project_items }}".ToLower() -eq "true"
-            if ("${{ inputs.project_url }}".Trim() -ne "") {
-              $projectUrl = "${{ inputs.project_url }}"
-            }
             $parsedLookback = 0
             if ([int]::TryParse("${{ inputs.project_lookback_days }}".Trim(), [ref]$parsedLookback)) {
               $lookbackDays = $parsedLookback

--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -21,6 +21,18 @@ on:
         description: 'Force removal of users with direct access, even if they are JIT elevated.'
         default: false
         type: boolean
+      sync_project_items:
+        description: 'Whether to add each repository''s issues and PRs to the AVM All Up GitHub Project.'
+        default: true
+        type: boolean
+      include_closed_project_items:
+        description: 'Also add closed issues and closed/merged PRs to the project (heavy historical back-fill). Off by default.'
+        default: false
+        type: boolean
+      project_url:
+        description: 'The GitHub Project (ProjectV2) URL to add each repository''s issues and PRs to.'
+        default: 'https://github.com/orgs/Azure/projects/1011'
+        type: string
   schedule:
     - cron: '33 */4 * * 1-5'
 
@@ -164,4 +176,59 @@ jobs:
             }
           }
           if ($hasError) { exit 1 }
+        shell: pwsh
+
+      - name: Add Repository Items to AVM All Up Project
+        if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.sync_project_items) }}
+        run: |
+
+          $triggerType = "${{ github.event_name }}"
+
+          $planOnly = $false
+          $includeClosed = $false
+          $projectUrl = "https://github.com/orgs/Azure/projects/1011"
+
+          if ($triggerType -eq "workflow_dispatch") {
+            $planOnly = "${{ inputs.plan_only }}".ToLower() -eq "true"
+            $includeClosed = "${{ inputs.include_closed_project_items }}".ToLower() -eq "true"
+            if ("${{ inputs.project_url }}".Trim() -ne "") {
+              $projectUrl = "${{ inputs.project_url }}"
+            }
+          }
+
+          Write-Output "Project URL: $projectUrl"
+          Write-Output "Include Closed: $includeClosed"
+          Write-Output "Plan Only: $planOnly"
+
+          ./scripts/Add-RepositoryItemsToProject.ps1 `
+            -repoUrl "${{ matrix.repoUrl }}" `
+            -projectUrl $projectUrl `
+            -includeClosed $includeClosed `
+            -planOnly $planOnly `
+            -outputDirectory "${{ github.workspace }}"
+
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Upload Project Sync Log Json
+        if: always() && hashFiles('project-sync.log.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.repoId }}.project-sync.log.json
+          path: project-sync.log.json
+
+      - name: Project Sync Error
+        if: always() && hashFiles('project-sync.log.json') != ''
+        run: |
+          $projectSyncLogJson = Get-Content -Path "${{ github.workspace }}/project-sync.log.json" -Raw
+          $projectSyncLog = ConvertFrom-Json $projectSyncLogJson
+          $projectSyncLog | ForEach-Object {
+            $severity = if ($_.severity) { $_.severity } else { "warning" }
+            if ($severity -eq "warning") {
+              echo "::warning title=${{ matrix.repoId }} project sync::$($_.message) Check the log file artifact for ${{ matrix.repoId }} to see the full details."
+            } else {
+              echo "::error title=${{ matrix.repoId }} project sync::$($_.message) Check the log file artifact for ${{ matrix.repoId }} to see the full details."
+            }
+          }
         shell: pwsh

--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -33,6 +33,10 @@ on:
         description: 'The GitHub Project (ProjectV2) URL to add each repository''s issues and PRs to.'
         default: 'https://github.com/orgs/Azure/projects/1011'
         type: string
+      project_lookback_days:
+        description: 'Only add issues/PRs updated in the last N days (keeps runs under API rate limits). Use 0 to disable the look-back and sweep everything not already on the project (one-off initial back-fill).'
+        default: '3'
+        type: string
   schedule:
     - cron: '33 */4 * * 1-5'
 
@@ -187,6 +191,11 @@ jobs:
           $planOnly = $false
           $includeClosed = $false
           $projectUrl = "https://github.com/orgs/Azure/projects/1011"
+          # Default look-back: scheduled/dispatch-by-event runs only consider items
+          # updated in the last 3 days, which keeps steady-state runs well under the
+          # GitHub API rate limits. A manual dispatch can override this (0 = full
+          # sweep for the one-off initial back-fill).
+          $lookbackDays = 3
 
           if ($triggerType -eq "workflow_dispatch") {
             $planOnly = "${{ inputs.plan_only }}".ToLower() -eq "true"
@@ -194,16 +203,25 @@ jobs:
             if ("${{ inputs.project_url }}".Trim() -ne "") {
               $projectUrl = "${{ inputs.project_url }}"
             }
+            $parsedLookback = 0
+            if ([int]::TryParse("${{ inputs.project_lookback_days }}".Trim(), [ref]$parsedLookback)) {
+              $lookbackDays = $parsedLookback
+            }
+            else {
+              Write-Output "Could not parse project_lookback_days '${{ inputs.project_lookback_days }}'; using default $lookbackDays."
+            }
           }
 
           Write-Output "Project URL: $projectUrl"
           Write-Output "Include Closed: $includeClosed"
+          Write-Output "Look-back Days: $lookbackDays"
           Write-Output "Plan Only: $planOnly"
 
           ./scripts/Add-RepositoryItemsToProject.ps1 `
             -repoUrl "${{ matrix.repoUrl }}" `
             -projectUrl $projectUrl `
             -includeClosed $includeClosed `
+            -lookbackDays $lookbackDays `
             -planOnly $planOnly `
             -outputDirectory "${{ github.workspace }}"
 

--- a/tf-repo-mgmt/scripts/Add-RepositoryItemsToProject.ps1
+++ b/tf-repo-mgmt/scripts/Add-RepositoryItemsToProject.ps1
@@ -19,6 +19,11 @@
 #     item's `projectItems`). `addProjectV2ItemById` is itself idempotent, so
 #     this is belt-and-braces and keeps the run rate-limit friendly.
 #   * With -planOnly, logs what WOULD be added without mutating the project.
+#   * -lookbackDays (default 3) bounds each run to items updated in the last N
+#     days: enumeration is ordered newest-updated-first and stops paging as soon
+#     as it crosses the cutoff, so steady-state runs fetch ~1 page per collection.
+#     -lookbackDays 0 disables the look-back and sweeps everything not already on
+#     the project (the one-off initial back-fill).
 #
 # All GitHub GraphQL calls (queries and the add mutation) are routed through
 # Invoke-GitHubCliWithRetry with incremental back-off and an extended retry-match
@@ -31,6 +36,7 @@ param(
     [string]$projectOwner = "Azure",
     [int]$projectNumber = 1011,
     [bool]$includeClosed = $false,
+    [int]$lookbackDays = 3,
     [bool]$planOnly = $false,
     [string]$outputDirectory = "."
 )
@@ -74,7 +80,6 @@ function Invoke-GhGraphQl {
         [string]$query,
         [string[]]$stringFields = @(), # passed via -f (always string)
         [string[]]$typedFields = @(),  # passed via -F (magic int/bool/null conversion)
-        [switch]$paginate,
         [int]$maxRetries = 10
     )
 
@@ -82,11 +87,6 @@ function Invoke-GhGraphQl {
     Set-Content -Path $queryFile -Value $query -Encoding utf8
 
     $arguments = @("api", "graphql")
-    if ($paginate) {
-        # Native GraphQL pagination: gh walks $endCursor/pageInfo itself and
-        # --slurp wraps every page into a single outer JSON array.
-        $arguments += @("--paginate", "--slurp")
-    }
     $arguments += @("-F", "query=@$($queryFile.FullName)")
     foreach ($field in $stringFields) { $arguments += @("-f", $field) }
     foreach ($field in $typedFields) { $arguments += @("-F", $field) }
@@ -152,16 +152,21 @@ query($owner: String!, $number: Int!) {
     return $null
 }
 
-# Enumerates every node in a repository collection ("issues" or "pullRequests")
-# for the given GraphQL states, returning a flat array of nodes each carrying its
-# node id, number, (isDraft for PRs) and projectItems membership.
+# Enumerates nodes in a repository collection ("issues" or "pullRequests") for
+# the given GraphQL states, newest-updated-first. Walks the cursor manually so we
+# can stop as soon as an item older than $cutoffUtc is seen (every later node is
+# older, given the UPDATED_AT DESC ordering) - this is the look-back that keeps
+# steady-state runs cheap. A $cutoffUtc of [datetime]::MinValue means "no
+# look-back" (full sweep). Returns @{ Nodes = <array>; RateRemaining = <int?> }
+# so the caller can surface remaining GraphQL budget, or $null on hard failure.
 function Get-RepositoryItems {
     param(
         [string]$owner,
         [string]$name,
         [ValidateSet("issues", "pullRequests")]
         [string]$collection,
-        [string]$statesGql
+        [string]$statesGql,
+        [datetime]$cutoffUtc = [datetime]::MinValue
     )
 
     $extraFields = ""
@@ -169,16 +174,22 @@ function Get-RepositoryItems {
 
     # Single-quoted template with placeholder tokens avoids escaping the GraphQL
     # `$owner`/`$name`/`$endCursor` variables against PowerShell interpolation.
+    # `rateLimit { remaining }` is essentially free and gives per-repo observability
+    # of the remaining primary GraphQL budget. `projectItems(first: 20)` is ample
+    # for the membership check (an item on >20 projects would just be re-added,
+    # which is idempotent).
     $template = @'
 query($owner: String!, $name: String!, $endCursor: String) {
+  rateLimit { remaining }
   repository(owner: $owner, name: $name) {
-    __COLLECTION__(states: [__STATES__], first: 100, after: $endCursor) {
+    __COLLECTION__(states: [__STATES__], first: 100, after: $endCursor, orderBy: { field: UPDATED_AT, direction: DESC }) {
       pageInfo { hasNextPage endCursor }
       nodes {
         id
         number
+        updatedAt
         __EXTRA__
-        projectItems(first: 100) { nodes { project { number } } }
+        projectItems(first: 20) { nodes { project { number } } }
       }
     }
   }
@@ -186,20 +197,49 @@ query($owner: String!, $name: String!, $endCursor: String) {
 '@
     $query = $template.Replace("__COLLECTION__", $collection).Replace("__STATES__", $statesGql).Replace("__EXTRA__", $extraFields)
 
-    $result = Invoke-GhGraphQl -query $query -stringFields @("owner=$owner", "name=$name") -paginate
-    if (-not $result.success) {
-        return $null
-    }
-
     $nodes = @()
-    foreach ($page in @($result.output)) {
-        $connection = $page.data.repository.$collection
-        if ($connection -and $connection.nodes) {
-            $nodes += $connection.nodes
+    $endCursor = $null
+    $rateRemaining = $null
+    $reachedCutoff = $false
+    $useCutoff = $cutoffUtc -gt [datetime]::MinValue
+
+    while ($true) {
+        $stringFields = @("owner=$owner", "name=$name")
+        # $endCursor is a nullable String; omit it on the first page so gh sends
+        # null (an absent nullable variable is treated as null by GraphQL).
+        if ($endCursor) { $stringFields += "endCursor=$endCursor" }
+
+        $result = Invoke-GhGraphQl -query $query -stringFields $stringFields
+        if (-not $result.success) {
+            return $null
         }
+
+        $data = $result.output.data
+        if ($data.rateLimit -and $null -ne $data.rateLimit.remaining) {
+            $rateRemaining = [int]$data.rateLimit.remaining
+        }
+
+        $connection = $data.repository.$collection
+        if (-not $connection) { break }
+
+        foreach ($node in @($connection.nodes)) {
+            if ($useCutoff -and $node.updatedAt) {
+                $nodeUpdatedUtc = ([datetimeoffset]$node.updatedAt).UtcDateTime
+                if ($nodeUpdatedUtc -lt $cutoffUtc) {
+                    # Newest-first ordering guarantees every later node is older.
+                    $reachedCutoff = $true
+                    break
+                }
+            }
+            $nodes += $node
+        }
+
+        if ($reachedCutoff) { break }
+        if (-not $connection.pageInfo.hasNextPage) { break }
+        $endCursor = $connection.pageInfo.endCursor
     }
 
-    return , $nodes
+    return @{ Nodes = @($nodes); RateRemaining = $rateRemaining }
 }
 
 # Returns $true if the item's projectItems already include the target project.
@@ -237,7 +277,7 @@ $repoName = $repoSplit[4]
 $orgAndRepoName = "$orgName/$repoName"
 
 Write-Host "$([Environment]::NewLine)<--->" -ForegroundColor Green
-Write-Host "Adding issues/PRs for $orgAndRepoName to project $projectOwner/$projectNumber (includeClosed=$includeClosed, planOnly=$planOnly)" -ForegroundColor Green
+Write-Host "Adding issues/PRs for $orgAndRepoName to project $projectOwner/$projectNumber (includeClosed=$includeClosed, lookbackDays=$lookbackDays, planOnly=$planOnly)" -ForegroundColor Green
 Write-Host "<--->$([Environment]::NewLine)" -ForegroundColor Green
 
 $project = Resolve-ProjectV2Id -owner $projectOwner -number $projectNumber
@@ -261,6 +301,22 @@ $projectId = $project.Id
 Write-Host "Resolved project '$($project.Title)' -> $projectId"
 
 # ---------------------------------------------------------------------------
+# Look-back cutoff. A value > 0 bounds each run to items updated within the last
+# N days (enumeration is newest-first and stops paging once it crosses the
+# cutoff). A value <= 0 disables the look-back and sweeps everything not already
+# on the project (the one-off initial back-fill). [datetime]::MinValue is the
+# "no look-back" sentinel that Get-RepositoryItems understands.
+# ---------------------------------------------------------------------------
+if ($lookbackDays -gt 0) {
+    $cutoffUtc = [datetime]::UtcNow.AddDays(-$lookbackDays)
+    Write-Host "Look-back: last $lookbackDays day(s) - items updated on/after $($cutoffUtc.ToString('u'))"
+}
+else {
+    $cutoffUtc = [datetime]::MinValue
+    Write-Host "Look-back: disabled - full sweep of all items not already on the project"
+}
+
+# ---------------------------------------------------------------------------
 # Build the work list: collection -> GraphQL states
 # ---------------------------------------------------------------------------
 $collections = @(
@@ -273,10 +329,11 @@ $totalAlready = 0
 $totalAdded = 0
 $totalWouldAdd = 0
 $totalFailed = 0
+$rateRemaining = $null
 
 foreach ($collection in $collections) {
-    $items = Get-RepositoryItems -owner $orgName -name $repoName -collection $collection.Name -statesGql $collection.States
-    if ($null -eq $items) {
+    $itemsResult = Get-RepositoryItems -owner $orgName -name $repoName -collection $collection.Name -statesGql $collection.States -cutoffUtc $cutoffUtc
+    if ($null -eq $itemsResult) {
         $message = "Failed to enumerate $($collection.Name) (states: $($collection.States)) for $orgAndRepoName after retries."
         Write-Warning $message
         $issueLog = Add-IssueToLog `
@@ -288,6 +345,9 @@ foreach ($collection in $collections) {
             -issueLogFile $projectLogFile
         continue
     }
+
+    $items = @($itemsResult.Nodes)
+    if ($null -ne $itemsResult.RateRemaining) { $rateRemaining = $itemsResult.RateRemaining }
 
     Write-Host "Found $($items.Count) $($collection.Name) (states: $($collection.States)) for $orgAndRepoName"
     $totalFound += $items.Count
@@ -342,6 +402,9 @@ if ($planOnly) {
 else {
     Write-Host "  added:        $totalAdded"
     Write-Host "  failed:       $totalFailed"
+}
+if ($null -ne $rateRemaining) {
+    Write-Host "  graphql budget remaining: $rateRemaining"
 }
 
 if ($issueLog.Count -gt 0) {

--- a/tf-repo-mgmt/scripts/Add-RepositoryItemsToProject.ps1
+++ b/tf-repo-mgmt/scripts/Add-RepositoryItemsToProject.ps1
@@ -1,0 +1,351 @@
+# Requires Environment Variables for GitHub Actions
+# GH_TOKEN - a token (e.g. GitHub App installation token) that has organization
+#            "Projects" read/write permission for the target project's owner.
+#
+# The GitHub CLI picks up GH_TOKEN automatically, so no `gh auth login` is
+# required before running this script.
+#
+# Adds a single repository's issues and pull requests to an org GitHub Project
+# (ProjectV2). This is the central, cap-free alternative to the built-in
+# Projects "auto-add" workflows (which are limited to 20 per project) and avoids
+# committing a per-repo workflow + installing an app/secret on every repo.
+#
+# Behaviour:
+#   * Enumerates the repo's OPEN issues and OPEN pull requests by default. Draft
+#     PRs are `state: OPEN`, so they are always included.
+#   * With -includeClosed, also enumerates CLOSED issues and CLOSED/MERGED PRs
+#     (a heavy, occasional historical back-fill).
+#   * Only items NOT already on the target project are added (checked via each
+#     item's `projectItems`). `addProjectV2ItemById` is itself idempotent, so
+#     this is belt-and-braces and keeps the run rate-limit friendly.
+#   * With -planOnly, logs what WOULD be added without mutating the project.
+#
+# All GitHub GraphQL calls (queries and the add mutation) are routed through
+# Invoke-GitHubCliWithRetry with incremental back-off and an extended retry-match
+# list so transient failures and primary/secondary rate limits are ridden out
+# rather than failing the run.
+
+param(
+    [string]$repoUrl = "https://github.com/Azure/terraform-azurerm-avm-ptn-example-repo",
+    [string]$projectUrl = "",
+    [string]$projectOwner = "Azure",
+    [int]$projectNumber = 1011,
+    [bool]$includeClosed = $false,
+    [bool]$planOnly = $false,
+    [string]$outputDirectory = "."
+)
+
+# Dot-source the shared cmdlet libs. `$PSScriptRoot` makes resolution independent
+# of the caller's working directory (the workflow runs from `tf-repo-mgmt/`, but
+# local debug runs can be from anywhere).
+$libDir = Join-Path $PSScriptRoot "lib"
+. (Join-Path $libDir "Logging.ps1")
+. (Join-Path $libDir "RetryHelpers.ps1")
+
+# Extended retry-match list: the default only covers "API rate limit exceeded".
+# We additionally cover GitHub's secondary/abuse rate limits and common transient
+# gateway/timeout failures so a busy run backs off and retries instead of failing.
+$retryOn = @(
+    "API rate limit exceeded",
+    "secondary rate limit",
+    "exceeded a secondary rate limit",
+    "was submitted too quickly",
+    "abuse detection",
+    "502 Bad Gateway",
+    "503 Service Unavailable",
+    "504 Gateway Time-out",
+    "Gateway Timeout",
+    "timeout awaiting response",
+    "Timeout was reached",
+    "connection reset",
+    "Server Error",
+    "EOF"
+)
+
+$projectLogFile = Join-Path $outputDirectory "project-sync.log"
+$projectLogFileJson = Join-Path $outputDirectory "project-sync.log.json"
+$issueLog = @()
+
+# Invokes `gh api graphql`, routing through the repo's retry/back-off helper.
+# The GraphQL document is written to a temp file and passed via `-F query=@file`
+# so multi-line queries never have to survive Start-Process argument quoting.
+function Invoke-GhGraphQl {
+    param(
+        [string]$query,
+        [string[]]$stringFields = @(), # passed via -f (always string)
+        [string[]]$typedFields = @(),  # passed via -F (magic int/bool/null conversion)
+        [switch]$paginate,
+        [int]$maxRetries = 10
+    )
+
+    $queryFile = New-TemporaryFile
+    Set-Content -Path $queryFile -Value $query -Encoding utf8
+
+    $arguments = @("api", "graphql")
+    if ($paginate) {
+        # Native GraphQL pagination: gh walks $endCursor/pageInfo itself and
+        # --slurp wraps every page into a single outer JSON array.
+        $arguments += @("--paginate", "--slurp")
+    }
+    $arguments += @("-F", "query=@$($queryFile.FullName)")
+    foreach ($field in $stringFields) { $arguments += @("-f", $field) }
+    foreach ($field in $typedFields) { $arguments += @("-F", $field) }
+
+    try {
+        $result = Invoke-GitHubCliWithRetry `
+            -commands @(@{ Arguments = $arguments }) `
+            -outputLog "gh.project.output.log" `
+            -errorLog "gh.project.error.log" `
+            -maxRetries $maxRetries `
+            -retryDelayIncremental 10 `
+            -retryOn $retryOn `
+            -printOutputOnError `
+            -returnOutputParsedFromJson
+
+        # Invoke-GitHubCliWithRetry returns an array (one entry per command).
+        # PowerShell usually unwraps a single-element array, but normalise to be
+        # safe so callers can rely on `.success` / `.output`.
+        if ($result -is [array]) { $result = $result[0] }
+        return $result
+    }
+    finally {
+        Remove-Item $queryFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Resolves a ProjectV2 node id from an owner + project number. Tries the owner as
+# an organization first (the AVM All Up project is org-owned) and falls back to a
+# user-owned project so a -projectUrl override still works.
+function Resolve-ProjectV2Id {
+    param([string]$owner, [int]$number)
+
+    $orgQuery = @'
+query($owner: String!, $number: Int!) {
+  organization(login: $owner) {
+    projectV2(number: $number) { id title }
+  }
+}
+'@
+    $result = Invoke-GhGraphQl -query $orgQuery -stringFields @("owner=$owner") -typedFields @("number=$number")
+    if ($result.success -and $result.output.data.organization.projectV2.id) {
+        return @{
+            Id    = $result.output.data.organization.projectV2.id
+            Title = $result.output.data.organization.projectV2.title
+        }
+    }
+
+    $userQuery = @'
+query($owner: String!, $number: Int!) {
+  user(login: $owner) {
+    projectV2(number: $number) { id title }
+  }
+}
+'@
+    $result = Invoke-GhGraphQl -query $userQuery -stringFields @("owner=$owner") -typedFields @("number=$number")
+    if ($result.success -and $result.output.data.user.projectV2.id) {
+        return @{
+            Id    = $result.output.data.user.projectV2.id
+            Title = $result.output.data.user.projectV2.title
+        }
+    }
+
+    return $null
+}
+
+# Enumerates every node in a repository collection ("issues" or "pullRequests")
+# for the given GraphQL states, returning a flat array of nodes each carrying its
+# node id, number, (isDraft for PRs) and projectItems membership.
+function Get-RepositoryItems {
+    param(
+        [string]$owner,
+        [string]$name,
+        [ValidateSet("issues", "pullRequests")]
+        [string]$collection,
+        [string]$statesGql
+    )
+
+    $extraFields = ""
+    if ($collection -eq "pullRequests") { $extraFields = "isDraft" }
+
+    # Single-quoted template with placeholder tokens avoids escaping the GraphQL
+    # `$owner`/`$name`/`$endCursor` variables against PowerShell interpolation.
+    $template = @'
+query($owner: String!, $name: String!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    __COLLECTION__(states: [__STATES__], first: 100, after: $endCursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        number
+        __EXTRA__
+        projectItems(first: 100) { nodes { project { number } } }
+      }
+    }
+  }
+}
+'@
+    $query = $template.Replace("__COLLECTION__", $collection).Replace("__STATES__", $statesGql).Replace("__EXTRA__", $extraFields)
+
+    $result = Invoke-GhGraphQl -query $query -stringFields @("owner=$owner", "name=$name") -paginate
+    if (-not $result.success) {
+        return $null
+    }
+
+    $nodes = @()
+    foreach ($page in @($result.output)) {
+        $connection = $page.data.repository.$collection
+        if ($connection -and $connection.nodes) {
+            $nodes += $connection.nodes
+        }
+    }
+
+    return , $nodes
+}
+
+# Returns $true if the item's projectItems already include the target project.
+function Test-ItemOnProject {
+    param($item, [int]$number)
+
+    foreach ($projectItem in @($item.projectItems.nodes)) {
+        if ($projectItem.project -and ([int]$projectItem.project.number) -eq $number) {
+            return $true
+        }
+    }
+    return $false
+}
+
+# ---------------------------------------------------------------------------
+# Resolve target project (owner/number can be overridden by a full project URL)
+# ---------------------------------------------------------------------------
+if ($projectUrl -and $projectUrl.Trim() -ne "") {
+    if ($projectUrl -match "orgs/([^/]+)/projects/(\d+)") {
+        $projectOwner = $Matches[1]
+        $projectNumber = [int]$Matches[2]
+    }
+    elseif ($projectUrl -match "users/([^/]+)/projects/(\d+)") {
+        $projectOwner = $Matches[1]
+        $projectNumber = [int]$Matches[2]
+    }
+    else {
+        Write-Warning "Could not parse projectUrl '$projectUrl'; falling back to owner '$projectOwner' / number $projectNumber."
+    }
+}
+
+$repoSplit = $repoUrl.Split("/")
+$orgName = $repoSplit[3]
+$repoName = $repoSplit[4]
+$orgAndRepoName = "$orgName/$repoName"
+
+Write-Host "$([Environment]::NewLine)<--->" -ForegroundColor Green
+Write-Host "Adding issues/PRs for $orgAndRepoName to project $projectOwner/$projectNumber (includeClosed=$includeClosed, planOnly=$planOnly)" -ForegroundColor Green
+Write-Host "<--->$([Environment]::NewLine)" -ForegroundColor Green
+
+$project = Resolve-ProjectV2Id -owner $projectOwner -number $projectNumber
+if ($null -eq $project) {
+    $message = "Could not resolve ProjectV2 id for $projectOwner/$projectNumber. Check the project exists and the token has organization Projects read/write permission."
+    Write-Error $message
+    $issueLog = Add-IssueToLog `
+        -orgAndRepoName $orgAndRepoName `
+        -type "project-sync" `
+        -message $message `
+        -severity "error" `
+        -issueLog $issueLog `
+        -issueLogFile $projectLogFile
+    if ($issueLog.Count -gt 0) {
+        ConvertTo-Json $issueLog -Depth 100 | Out-File $projectLogFileJson
+    }
+    exit 0
+}
+
+$projectId = $project.Id
+Write-Host "Resolved project '$($project.Title)' -> $projectId"
+
+# ---------------------------------------------------------------------------
+# Build the work list: collection -> GraphQL states
+# ---------------------------------------------------------------------------
+$collections = @(
+    @{ Name = "issues"; States = if ($includeClosed) { "OPEN, CLOSED" } else { "OPEN" } },
+    @{ Name = "pullRequests"; States = if ($includeClosed) { "OPEN, CLOSED, MERGED" } else { "OPEN" } }
+)
+
+$totalFound = 0
+$totalAlready = 0
+$totalAdded = 0
+$totalWouldAdd = 0
+$totalFailed = 0
+
+foreach ($collection in $collections) {
+    $items = Get-RepositoryItems -owner $orgName -name $repoName -collection $collection.Name -statesGql $collection.States
+    if ($null -eq $items) {
+        $message = "Failed to enumerate $($collection.Name) (states: $($collection.States)) for $orgAndRepoName after retries."
+        Write-Warning $message
+        $issueLog = Add-IssueToLog `
+            -orgAndRepoName $orgAndRepoName `
+            -type "project-sync" `
+            -message $message `
+            -severity "warning" `
+            -issueLog $issueLog `
+            -issueLogFile $projectLogFile
+        continue
+    }
+
+    Write-Host "Found $($items.Count) $($collection.Name) (states: $($collection.States)) for $orgAndRepoName"
+    $totalFound += $items.Count
+
+    foreach ($item in $items) {
+        if (Test-ItemOnProject -item $item -number $projectNumber) {
+            $totalAlready++
+            continue
+        }
+
+        if ($planOnly) {
+            Write-Host "  [plan] would add $($collection.Name) #$($item.number) ($($item.id))"
+            $totalWouldAdd++
+            continue
+        }
+
+        $mutation = @'
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+    item { id }
+  }
+}
+'@
+        $addResult = Invoke-GhGraphQl -query $mutation -stringFields @("projectId=$projectId", "contentId=$($item.id)")
+
+        if ($addResult.success -and $addResult.output.data.addProjectV2ItemById.item.id) {
+            Write-Host "  added $($collection.Name) #$($item.number) -> $($addResult.output.data.addProjectV2ItemById.item.id)"
+            $totalAdded++
+        }
+        else {
+            $message = "Failed to add $($collection.Name) #$($item.number) ($($item.id)) to project $projectOwner/$projectNumber for $orgAndRepoName."
+            Write-Warning $message
+            $totalFailed++
+            $issueLog = Add-IssueToLog `
+                -orgAndRepoName $orgAndRepoName `
+                -type "project-sync" `
+                -message $message `
+                -data @{ collection = $collection.Name; number = $item.number; contentId = $item.id } `
+                -severity "warning" `
+                -issueLog $issueLog `
+                -issueLogFile $projectLogFile
+        }
+    }
+}
+
+Write-Host "$([Environment]::NewLine)Project sync summary for $orgAndRepoName" -ForegroundColor Cyan
+Write-Host "  found:        $totalFound"
+Write-Host "  already on:   $totalAlready"
+if ($planOnly) {
+    Write-Host "  would add:    $totalWouldAdd (planOnly)"
+}
+else {
+    Write-Host "  added:        $totalAdded"
+    Write-Host "  failed:       $totalFailed"
+}
+
+if ($issueLog.Count -gt 0) {
+    ConvertTo-Json $issueLog -Depth 100 | Out-File $projectLogFileJson
+}
+
+exit 0


### PR DESCRIPTION
## What & why

The org-wide GitHub Project **1011 ("AVM All Up")** gives us a single place to see every AVM item. The built-in Projects "auto-add" workflows are capped at **20 per project**, and `Azure/Azure-Verified-Modules`, `azure/bicep-registry-modules` and `azure/avm-terraform-governance` already consume those slots. That leaves the **~140 AVM Terraform module repos** with no way in.

The obvious alternative — a per-repo auto-add workflow — would mean installing the AVM GitHub App + secret on every one of those repos, a blast radius we want to avoid.

Instead, this PR extends the existing central **`tf-repo-mgmt.yml`** governance workflow (which already fans out over every AVM Terraform repo via its matrix) to **add each repo's issues and PRs to project 1011 centrally**, using the app token that already exists on this governance repo. No new app installs or secrets anywhere else.

## How it works

A new script, **`tf-repo-mgmt/scripts/Add-RepositoryItemsToProject.ps1`**, runs per matrix repo and:
- Enumerates the repo's **open issues and open PRs** (draft PRs are `state: OPEN`, so they're always included) via GraphQL.
- **Skips items already on the project** (checked via each item's `projectItems`), then adds the rest with `addProjectV2ItemById` (itself idempotent).
- Honours the workflow's existing `plan_only` semantics for dry-runs, and logs per-item failures as **non-fatal warnings** so a project hiccup never fails the governance job.
- Optional `include_closed_project_items` input also back-fills closed issues and closed/merged PRs.

## Rate-limit control (look-back window)

To keep steady-state runs comfortably under GitHub's API limits, enumeration is ordered **`UPDATED_AT DESC`** and a **`-lookbackDays` (default 3)** window makes the script **early-terminate** as soon as it crosses the cutoff — so a normal run fetches ~1 page per collection per repo. `-lookbackDays 0` disables the look-back and sweeps **everything** not yet on the project, for the one-off initial back-fill (optionally batched via the existing `repositories` input). Remaining GraphQL budget is logged per repo for observability.

Measured cost (via `rateLimit { cost remaining }` in live queries): a 100-item enumeration page **incl. the inline `projectItems` membership check is just 1 point** — reads are cheap. The real pressure is **writes** (secondary limits), which only bite on the one-time back-fill; the matrix already shards one-repo-per-job with retry/back-off.

### New `workflow_dispatch` inputs
| Input | Type | Default | Purpose |
| --- | --- | --- | --- |
| `sync_project_items` | boolean | `true` | Toggle the project-sync step off |
| `include_closed_project_items` | boolean | `false` | Also add closed issues + closed/merged PRs |
| `project_url` | string | `…/orgs/Azure/projects/1011` | Target ProjectV2 |
| `project_lookback_days` | string | `'3'` | Only add items updated in the last N days; `0` = full sweep |

## Validation
- **Script:** AST parse clean; PSScriptAnalyzer clean apart from the repo-wide `Write-Host` convention and one cosmetic plural-noun.
- **Workflow:** `actionlint` exit 0; YAML validated with pyyaml.
- **Live read-only dry-runs** (`-planOnly`) against `terraform-azurerm-avm-res-keyvault-vault`: 3-day look-back fetches one page/collection and early-breaks; full sweep reconciles exactly with prior counts (42 open items; 299 incl. closed across 3 correctly-cursored PR pages; already-on items correctly skipped).

### Test Runs on `terraform-azurerm-avm-res-cdn-profile`

Both successful:
- https://github.com/Azure/avm-terraform-governance/actions/runs/29341416337 (with default 3d lookback period)
- https://github.com/Azure/avm-terraform-governance/actions/runs/29341666474 (with lookback period set to 0 so adds all open issues/PRs)

## Suggested rollout
1. Run once with `project_lookback_days: 0` and `plan_only: false` to back-fill everything (optionally batch via `repositories`).
2. Let the scheduled 3-day window keep it current; widen the default later if desired.

_No changes to any downstream module repos._