### PR TITLE
fix(dependabot): group updates into two PRs and use existing AVM labels

### DIFF
--- a/managed-files/root/.github/dependabot.yml
+++ b/managed-files/root/.github/dependabot.yml
@@ -21,9 +21,12 @@ updates:
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
+    groups:
+      terraform:
+        patterns:
+          - "*"
     labels:
-      - dependencies
-      - terraform
+      - "Language: Terraform :globe_with_meridians:"
     commit-message:
       prefix: chore
       include: scope
@@ -37,9 +40,12 @@ updates:
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
-      - dependencies
-      - github-actions
+      - "Type: CI :rocket:"
     commit-message:
       prefix: chore
       include: scope

--- a/managed-files/root/.github/dependabot.yml
+++ b/managed-files/root/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
     groups:
       terraform:
         patterns:
@@ -39,7 +38,6 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Refines the centrally-managed Dependabot template (`managed-files/root/.github/dependabot.yml`) that `repository_sync` rolls out to every AVM Terraform module repo. Fixes two problems described in the tracking issue (azure-cloud-native/Azure-Verified-Modules#174):

1. **Too many PRs** — no `groups:` config meant one PR per outdated dependency (up to the limit) per ecosystem per repo, producing 149+ near-identical PRs fleet-wide for a single Action bump.
2. **Broken labels** — the template referenced labels (`dependencies`, `terraform`, `github-actions`) that don't exist on the repos, so Dependabot posted "labels could not be found" and applied none.

## Changes

- Added a catch-all `groups:` block (`patterns: ["*"]`) to each `package-ecosystem` entry. Since a group only merges within one ecosystem, this yields exactly **two PRs per repo**: one grouping all Terraform updates (across `/`, `/examples/**`, `/modules/**`), one grouping all GitHub Actions updates.
- Remapped `labels:` to existing AVM standard labels (created on every repo by `repository_sync`'s `github.labels.tf`):
  - terraform → `Language: Terraform :globe_with_meridians:`
  - github-actions → `Type: CI :rocket:`
- Removed `open-pull-requests-limit: 5` from both entries (redundant once grouped; defaults to 5 anyway) per review feedback.

## Validation

Tested on a live module repo before rollout — Azure/terraform-azurerm-avm-ptn-example-repo#139 merged to `main`, which auto-triggered a Dependabot run:

- ✅ Exactly two grouped PRs created: `bump the terraform group across 5 directories with 2 updates` (labeled `Language: Terraform :globe_with_meridians:`) and `bump the github-actions group with 7 updates` (labeled `Type: CI :rocket:`).
- ✅ No "labels could not be found" comment.
- ✅ All previous individual PRs auto-closed as "Superseded by #140/#141" — zero stragglers.

Once merged here, `repository_sync` rolls this out fleet-wide; each repo self-heals on its next Dependabot run (weekly schedule or manual "Check for updates"), grouping bumps and auto-closing superseded PRs.

Tracking issue: https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules/issues/174