### PR TITLE
ci(dependabot): auto-apply pre-commit fixes to Dependabot PR branches

### DIFF
--- a/.github/workflows/dependabot-precommit.yml
+++ b/.github/workflows/dependabot-precommit.yml
@@ -1,0 +1,127 @@
+---
+name: dependabot-precommit
+
+# Runs pre-commit (fmt, terraform-docs, etc.) against open Dependabot PR branches
+# across the AVM Terraform module fleet and pushes the regenerated files back to
+# each PR branch, so the module's own "PR Check (Lint, Format, Validate)" passes.
+#
+# Why this exists: Dependabot only edits the version string in a manifest; it cannot
+# run repo hooks, so provider/module bumps leave generated docs (README version
+# tables) stale and the docs check fails. This workflow closes that gap centrally,
+# reusing the same GitHub App token + repo matrix + ./avm pre-commit pattern as
+# pre-commit-cron.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repositories:
+        description: "Override the target repositories, use a comma separated list. Leave as All to run on all repositories."
+        default: "All"
+        type: string
+  # Dependabot opens/updates PRs on its weekly schedule (Mondays); run a little
+  # afterwards to fix them up. Left commented to match pre-commit-cron.yml's
+  # dispatch-first posture — enable when ready.
+  # schedule:
+  #   - cron: "17 7 * * 1"
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    environment: avm
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      matrixParallel: ${{ steps.matrix.outputs.matrixParallel }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Generate Matrix
+        uses: ./.github/actions/avm-repos
+        id: matrix
+        with:
+          repositories: ${{ inputs.repositories }}
+          clientId: ${{ secrets.AVM_APP_CLIENT_ID }}
+          privateKey: ${{ secrets.AVM_APP_PRIVATE_KEY }}
+
+  fix-dependabot-prs:
+    name: ${{ matrix.repoId }} (${{ matrix.repoUrl }})
+    runs-on: ubuntu-latest
+    environment: avm
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJson(needs.generate-matrix.outputs.matrixParallel) }}
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repoName }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: List open Dependabot PRs
+        id: list
+        run: |
+          prs=$(gh pr list --repo "${{ matrix.repoFullName }}" --state open --app dependabot --json number,headRefName)
+          echo "count=$(echo "$prs" | jq 'length')" >> "$GITHUB_OUTPUT"
+          # Compact single-line JSON so it survives as a step output.
+          echo "prs=$(echo "$prs" | jq -c '.')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Apply pre-commit to each Dependabot PR branch
+        if: steps.list.outputs.count != '0'
+        run: |
+          set -uo pipefail
+
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${{ matrix.repoFullName }}.git" repo
+          cd repo
+
+          echo '${{ steps.list.outputs.prs }}' | jq -c '.[]' | while read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            branch=$(echo "$pr" | jq -r '.headRefName')
+            echo "::group::PR #${number} (${branch})"
+
+            git fetch origin "${branch}"
+            git checkout -B "${branch}" "origin/${branch}"
+
+            # pre-commit intentionally returns non-zero when it modifies files, so we
+            # don't treat that as fatal; run twice (fix, then verify) like pre-commit-cron.
+            chmod a+x ./avm
+            ./avm pre-commit || ./avm pre-commit || true
+
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "No pre-commit changes for PR #${number}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            git add .
+            git commit -m "chore(deps): apply pre-commit fixes"
+            git push origin "HEAD:${branch}"
+            echo "Pushed pre-commit fixes to PR #${number}"
+            echo "::endgroup::"
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/dependabot-precommit.yml
+++ b/.github/workflows/dependabot-precommit.yml
@@ -80,7 +80,12 @@ jobs:
       - name: List open Dependabot PRs
         id: list
         run: |
-          prs=$(gh pr list --repo "${{ matrix.repoFullName }}" --state open --app dependabot --json number,headRefName)
+          # Only Terraform-ecosystem Dependabot PRs need pre-commit: they bump
+          # provider/module versions that feed the generated README tables. The
+          # github-actions ecosystem PRs produce no pre-commit diff, so filter
+          # them out up front (by the label dependabot.yml stamps on Terraform
+          # PRs) to avoid a wasted clone + pre-commit run on each one.
+          prs=$(gh pr list --repo "${{ matrix.repoFullName }}" --state open --app dependabot --label "Language: Terraform :globe_with_meridians:" --json number,headRefName)
           echo "count=$(echo "$prs" | jq 'length')" >> "$GITHUB_OUTPUT"
           # Compact single-line JSON so it survives as a step output.
           echo "prs=$(echo "$prs" | jq -c '.')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-precommit.yml
+++ b/.github/workflows/dependabot-precommit.yml
@@ -80,11 +80,8 @@ jobs:
       - name: List open Dependabot PRs
         id: list
         run: |
-          # Only Terraform-ecosystem Dependabot PRs need pre-commit: they bump
-          # provider/module versions that feed the generated README tables. The
-          # github-actions ecosystem PRs produce no pre-commit diff, so filter
-          # them out up front (by the label dependabot.yml stamps on Terraform
-          # PRs) to avoid a wasted clone + pre-commit run on each one.
+          # Only Terraform-ecosystem Dependabot PRs need pre-commit (github-actions
+          # bumps produce no diff), so filter by the label dependabot.yml stamps on them.
           prs=$(gh pr list --repo "${{ matrix.repoFullName }}" --state open --app dependabot --label "Language: Terraform :globe_with_meridians:" --json number,headRefName)
           echo "count=$(echo "$prs" | jq 'length')" >> "$GITHUB_OUTPUT"
           # Compact single-line JSON so it survives as a step output.


### PR DESCRIPTION
## Problem

Dependabot only rewrites the version string in a manifest (a provider or module version bump). It cannot run this repo's hooks, so the generated docs — most notably the terraform-docs README version tables — go stale on the Dependabot branch. The module's own **PR Check (Lint, Format, Validate)** docs check then fails, and every Dependabot PR sits red until a human manually runs `./avm pre-commit` and pushes the result. This is the docs-drift problem tracked in https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules/issues/174.

## What this does

Adds a new **central** workflow at `.github/workflows/dependabot-precommit.yml` (it lives only in the governance repo and is **not** synced to module repos, so it does not go under `managed-files/`). It:

1. Builds the module-fleet matrix via `./.github/actions/avm-repos`.
2. Mints a repo-scoped GitHub App token (`AVM_APP_CLIENT_ID` / `AVM_APP_PRIVATE_KEY`).
3. Lists open **Terraform-ecosystem** Dependabot PRs per repo with `gh pr list --state open --app dependabot --label "Language: Terraform :globe_with_meridians:"`.
4. For each PR branch: checks it out, runs `./avm pre-commit`, and pushes any regenerated files back to that same Dependabot branch so the module's docs check passes.

It reuses the same GitHub App token + repo matrix + `./avm pre-commit` pattern as `pre-commit-cron.yml`, including the identical pinned action SHAs (`create-github-app-token@bcd2ba49…` v3.2.0, `checkout@df4cb1c…` v6.0.3).

## Tradeoff to be aware of

Pushing a pre-commit commit onto a Dependabot PR branch makes Dependabot treat the branch as human-modified, so it **stops auto-rebasing / force-updating that PR.** We accept this because the alternative is a PR that stays red on the docs check and can't be merged anyway. If an affected PR later falls behind `main`, comment **`@dependabot rebase`** to update it on demand.

## Design notes

- **Central "Variant B", not per-module:** Fixing this centrally (one workflow in governance that fans out over the fleet) avoids having to sync yet another workflow into every module repo and keeps the App-token/matrix logic in one place, consistent with `pre-commit-cron.yml`.
- **Why not `pull_request_target`:** A per-module `pull_request_target` workflow would run with the target repo's secrets against Dependabot PR head refs, which is exactly the pattern GitHub warns about for privilege escalation, and Dependabot-triggered runs get a read-only token / restricted secrets anyway. The central App-token approach sidesteps that entirely.
- **Terraform PRs only:** Each module repo's `dependabot.yml` manages two ecosystems — `terraform` and `github-actions`. Only the Terraform bumps change `.tf` inputs that feed the generated README tables; github-actions bumps produce no pre-commit diff. The PR listing filters on the `Language: Terraform :globe_with_meridians:` label (applied deterministically by the synced dependabot config) so github-actions PRs never trigger a wasted clone + pre-commit run.
- **Schedule left disabled:** Trigger is `workflow_dispatch` only; the weekly `schedule` is left commented out (matching `pre-commit-cron.yml`'s dispatch-first posture) pending review. Enabling it is a separate follow-up PR that just uncomments the `schedule:` block.

## Related

- Complements #521, which grouped Dependabot updates into two PRs and fixed labels.
- Tracking issue: https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules/issues/174