### PR TITLE
ci(dependabot): schedule pre-commit fixes

### DIFF
--- a/.github/workflows/dependabot-precommit.yml
+++ b/.github/workflows/dependabot-precommit.yml
@@ -18,11 +18,10 @@ on:
         description: "Override the target repositories, use a comma separated list. Leave as All to run on all repositories."
         default: "All"
         type: string
-  # Dependabot opens/updates PRs on its weekly schedule (Mondays); run a little
-  # afterwards to fix them up. Left commented to match pre-commit-cron.yml's
-  # dispatch-first posture — enable when ready.
-  # schedule:
-  #   - cron: "17 7 * * 1"
+  # Runs after Monday Dependabot updates; workflow_dispatch remains available
+  # for scoped or manual runs.
+  schedule:
+    - cron: "17 7 * * 1"
 
 permissions:
   id-token: write
@@ -111,7 +110,7 @@ jobs:
             # pre-commit intentionally returns non-zero when it modifies files, so we
             # don't treat that as fatal; run twice (fix, then verify) like pre-commit-cron.
             chmod a+x ./avm
-            ./avm pre-commit || ./avm pre-commit || true
+            ./avm pre-commit || ./avm pre-commit
 
             if [ -z "$(git status --porcelain)" ]; then
               echo "No pre-commit changes for PR #${number}"


### PR DESCRIPTION
The workflow was manually validated against these Terraform Dependabot PRs: [example repo #149](https://github.com/Azure/terraform-azurerm-avm-ptn-example-repo/pull/149), [confidential compute #60](https://github.com/Azure/terraform-azurerm-avm-ptn-confidential-compute/pull/60), [FinOps Hub #42](https://github.com/Azure/terraform-azurerm-avm-ptn-finopstoolkit-finopshub/pull/42), and [AAD Domain Services #43](https://github.com/Azure/terraform-azurerm-avm-res-aad-domainservice/pull/43). This enables the Monday schedule for fleet-wide automatic runs while keeping manual dispatch available for scoped runs.

Pre-commit may return nonzero on the first pass after modifying files, so the workflow still runs it a second time to verify the fixes. Removing the final `|| true` prevents a persistent second-pass failure from being masked and stops the workflow before it can commit or push partial changes.