### PR TITLE
fix(tf-repo-mgmt): resolve state lock recovery helper in the correct scope

### DIFF
--- a/tf-repo-mgmt/scripts/lib/RetryHelpers.ps1
+++ b/tf-repo-mgmt/scripts/lib/RetryHelpers.ps1
@@ -26,15 +26,19 @@ function Invoke-TerraformWithRetry {
     # The repository sync is the only writer of each repo's state and runs on a
     # 4 hourly schedule, so any lock we hit is left over from a cancelled or
     # crashed run rather than a concurrent one. Break it and retry.
+    # State is passed through Context rather than a closure: GetNewClosure()
+    # rebinds the script block to a dynamic module, which cannot resolve the
+    # helper functions this file dot-sources into the caller's script scope.
     $recoveryActions = @(
         @{
             Name        = "terraform state lock"
             Pattern     = "Error acquiring the state lock"
             MaxAttempts = 3
+            Context     = @{ workingDirectory = $workingDirectory }
             Action      = {
-                param([string[]]$errorOutput)
-                Clear-TerraformStateLock -errorOutput $errorOutput -workingDirectory $workingDirectory
-            }.GetNewClosure()
+                param([string[]]$errorOutput, [hashtable]$context)
+                Clear-TerraformStateLock -errorOutput $errorOutput -workingDirectory $context.workingDirectory
+            }
         }
     )
 
@@ -208,7 +212,15 @@ function Invoke-CommandWithRetry {
 
                         $recovery.Attempts = [int]$recovery.Attempts + 1
                         Write-Host "Attempting recovery for '$($recovery.Name)' (attempt $($recovery.Attempts) of $maxRecoveryAttempts)."
-                        if (& $recovery.Action $errorOutput) {
+
+                        $recovered = $false
+                        try {
+                            $recovered = [bool](& $recovery.Action $errorOutput $recovery.Context)
+                        } catch {
+                            Write-Warning "Recovery for '$($recovery.Name)' threw an error: $_"
+                        }
+
+                        if ($recovered) {
                             $shouldRetry = $true
                             break
                         }


### PR DESCRIPTION
Follow-up to #528. The state lock recovery hook fired correctly on the first scheduled run after that merge, but the recovery itself blew up:

```
Attempting recovery for 'terraform state lock' (attempt 1 of 3).
Clear-TerraformStateLock: .../tf-repo-mgmt/scripts/lib/RetryHelpers.ps1:36
     | The term 'Clear-TerraformStateLock' is not recognized as a name of a
     | cmdlet, function, script file, or executable program.
```

This is failing **every scheduled run**, and the same error hits all three repos that currently hold stale locks:

| Repo | Job (run 30516652296) |
| --- | --- |
| `avm-res-network-expressrouteport` | 90787986304 |
| `avm-res-sql-instancepool` | 90787989555 |
| `avm-res-storage-storageaccount` | 90787989714 |

## Cause

The recovery action used `.GetNewClosure()` to capture `$workingDirectory`. That rebinds the script block to a **new dynamic module**, and command lookup from a dynamic module falls back to the **global** scope. `Clear-TerraformStateLock` is dot-sourced into `Invoke-RepositorySync.ps1`'s *script* scope, so it was invisible from inside the closure and every recovery attempt failed.

Two things made this worse than a simple failed recovery:

1. It only reproduces through the real invocation chain the workflow uses — `pwsh -command ". '<step>'"` → `./Invoke-RepositorySync.ps1` → `. lib/RetryHelpers.ps1`. The original harness dot-sourced the lib at the top level of a `pwsh -File` script, which resolves differently, so it gave a false pass.
2. GitHub's built-in `pwsh` shell prepends `$ErrorActionPreference = 'stop'`, which makes the command-not-found error **terminating**. The step died on the spot — note the log jumps straight from the error to `##[error]Process completed with exit code 1`, never reaching the normal `Error Log:` dump.

## Fix

- Pass the working directory through a `Context` hash table instead of a closure. A plain script block keeps the session state of the file that defines it, so the helper resolves.
- Wrap the recovery invocation in `try`/`catch` so a recovery action that throws degrades to the normal failure path instead of killing the whole step under `ErrorActionPreference = stop`.

## Validation

The harness now drives the end-to-end cases through the same chain as the workflow **and** sets `$ErrorActionPreference = 'stop'` exactly as GitHub's `pwsh` shell does, so this class of bug can't slip through again. Verified it fails against the pre-fix code from 656e2a5 and passes against this change.

| Case | Result |
| --- | --- |
| Stale lock is force-unlocked and the command retried (workflow scope) | pass — 3 calls: `plan`, `force-unlock -force <id>`, `plan` |
| Sticky lock stops at the attempt cap instead of looping (workflow scope) | pass — exactly 3 `force-unlock` attempts, 7 calls, clean failure |
| Unparseable lock ID returns `$false` rather than retrying | pass |
| Lock ID parsed from raw ANSI/box-drawn terraform output | pass |
| Recovery action that throws degrades to the normal failure path | pass — warns, returns a clean failure, script reaches the end |

Parse check clean; PSScriptAnalyzer reports no new findings (only the pre-existing `PSAvoidUsingWriteHost` warnings).

Also checked `terraform show -json` in `TerraformOperations.ps1`, which bypasses the retry wrapper — it only reads the local `.tfplan` file and never touches remote state, so it cannot hit a state lock. No change needed. `.GetNewClosure()` is not used anywhere else in the repo.