### PR TITLE
feat(tf-repo-mgmt): stacked managed-files overlays + canary-tooling cohort

### DIFF
--- a/managed-files/canary-tooling/.github/workflows/pr-check.yml
+++ b/managed-files/canary-tooling/.github/workflows/pr-check.yml
@@ -1,0 +1,30 @@
+# Canary-tooling override exercising the PowerShell Gallery toolchain instead of the container/make toolchain.
+---
+name: PR Check
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  check:
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checking for fork
+        shell: pwsh
+        run: |
+          $isFork = "${{ github.event.pull_request.head.repo.fork }}"
+          if($isFork -eq "true") {
+            echo "### WARNING: This workflow is disabled for forked repositories. Please follow the [release branch process](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-create-a-pull-request-to-the-upstream-repository) if end to end tests are required." >> $env:GITHUB_STEP_SUMMARY
+          }
+
+  run-managed-workflow:
+    if: github.event.pull_request.head.repo.fork == false
+    uses: Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@main
+    name: run managed workflow
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read

--- a/managed-files/canary-tooling/avm
+++ b/managed-files/canary-tooling/avm
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+cat >&2 <<'EOF'
+avm: this launcher is no longer supported.
+
+The container/make based AVM toolchain has been replaced by the Avm.Authoring
+PowerShell module. Install it from the PowerShell Gallery and run avm from
+PowerShell instead:
+
+    Install-PSResource -Name Avm.Authoring -Scope CurrentUser -TrustRepository
+    Import-Module Avm.Authoring
+    avm --help
+
+See https://github.com/Azure/azure-verified-modules-tools for details.
+EOF
+
+exit 1

--- a/managed-files/canary-tooling/avm.bat
+++ b/managed-files/canary-tooling/avm.bat
@@ -1,0 +1,15 @@
+@echo off
+
+echo avm: this launcher is no longer supported. 1>&2
+echo( 1>&2
+echo The container/make based AVM toolchain has been replaced by the Avm.Authoring 1>&2
+echo PowerShell module. Install it from the PowerShell Gallery and run avm from 1>&2
+echo PowerShell instead: 1>&2
+echo( 1>&2
+echo     Install-PSResource -Name Avm.Authoring -Scope CurrentUser -TrustRepository 1>&2
+echo     Import-Module Avm.Authoring 1>&2
+echo     avm --help 1>&2
+echo( 1>&2
+echo See https://github.com/Azure/azure-verified-modules-tools for details. 1>&2
+
+exit /b 1

--- a/managed-files/canary-tooling/avm.ps1
+++ b/managed-files/canary-tooling/avm.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+  [string[]]$Target
+)
+
+Set-StrictMode -Version 3.0
+
+$message = @'
+avm: this launcher is no longer supported.
+
+The container/make based AVM toolchain has been replaced by the Avm.Authoring
+PowerShell module. Install it from the PowerShell Gallery and run avm from
+PowerShell instead:
+
+    Install-PSResource -Name Avm.Authoring -Scope CurrentUser -TrustRepository
+    Import-Module Avm.Authoring
+    avm --help
+
+See https://github.com/Azure/azure-verified-modules-tools for details.
+'@
+
+[Console]::Error.WriteLine($message)
+exit 1

--- a/tf-repo-mgmt/repository-config/config.json
+++ b/tf-repo-mgmt/repository-config/config.json
@@ -14,6 +14,7 @@
     {
       "name": "canary",
       "managedFilesAdditional": "canary",
+      "managedFilesOrder": 10,
       "repositories": [
         "avm-ptn-example-repo",
         "avm-res-devopsinfrastructure-pool",
@@ -32,6 +33,7 @@
     {
       "name": "canary-tooling",
       "managedFilesAdditional": "canary-tooling",
+      "managedFilesOrder": 20,
       "repositories": [
         "avm-ptn-example-repo"
       ],
@@ -72,6 +74,7 @@
     {
       "name": "azure-landing-zones",
       "managedFilesAdditional": "alz",
+      "managedFilesOrder": 10,
       "excludedManagedFiles": [
         ".github/ISSUE_TEMPLATE/avm_module_issue.yml",
         ".github/ISSUE_TEMPLATE/avm_question_feedback.yml"

--- a/tf-repo-mgmt/repository-config/config.json
+++ b/tf-repo-mgmt/repository-config/config.json
@@ -30,6 +30,16 @@
       ]
     },
     {
+      "name": "canary-tooling",
+      "managedFilesAdditional": "canary-tooling",
+      "repositories": [
+        "avm-ptn-example-repo"
+      ],
+      "topics": [
+        "canary-tooling"
+      ]
+    },
+    {
       "name": "azure-verified-modules-tier-1",
       "repositories": [
         "avm-ptn-example-repo"

--- a/tf-repo-mgmt/repository-config/config.json
+++ b/tf-repo-mgmt/repository-config/config.json
@@ -34,6 +34,9 @@
       "name": "canary-tooling",
       "managedFilesAdditional": "canary-tooling",
       "managedFilesOrder": 20,
+      "workloadIdentityFederationSubjectClaimOverrides": {
+        "jobWorkflowRef": "Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@refs/heads/main"
+      },
       "repositories": [
         "avm-ptn-example-repo"
       ],

--- a/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
+++ b/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
@@ -204,6 +204,12 @@ $terraformVariables = @{
     topics = $settings.Topics
 }
 
+# Only emit the override when a group actually sets it. Writing a null would
+# clobber the Terraform-side default for every other repository.
+if ($settings.WorkloadIdentityFederationSubjectClaimOverrides.ContainsKey("jobWorkflowRef")) {
+    $terraformVariables["github_job_workflow_ref"] = $settings.WorkloadIdentityFederationSubjectClaimOverrides["jobWorkflowRef"]
+}
+
 $terraformVariables | ConvertTo-Json -Depth 100 | Out-File "$terraformModulePath/terraform.tfvars.json"
 
 $preTerraformIssueCount = $issueLog.Count

--- a/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
+++ b/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
@@ -77,7 +77,7 @@ $repositoryConfig = Get-Content -Path $repoConfigFilePath -Raw | ConvertFrom-Jso
 $settings = Resolve-RepositorySettings -repositoryConfig $repositoryConfig -repoId $repoId
 $managedFiles = Build-ManagedFilesMap `
     -baseDir $managedFilesBaseDir `
-    -overlay $settings.ManagedFilesAdditional `
+    -overlays $settings.ManagedFilesAdditional `
     -excluded $settings.ExcludedManagedFiles `
     -repoId $repoId
 

--- a/tf-repo-mgmt/scripts/lib/ManagedFiles.ps1
+++ b/tf-repo-mgmt/scripts/lib/ManagedFiles.ps1
@@ -1,8 +1,8 @@
 # Builds the managed-files map
 # (target path -> @{ Source = absolute source path; Mode = git index mode })
 # that is passed to Sync-RepoFiles. Walking the filesystem here keeps the
-# rest of the sync free of directory traversal and lets us apply overlay
-# merging + exclusions in one place.
+# rest of the sync free of directory traversal and lets us apply overlays in
+# order (with later overlays winning) plus exclusions in one place.
 #
 # `Mode` is the git tree-entry mode ("100644" or "100755") read from this
 # governance repo's own git index, so the executable bit recorded here is
@@ -70,21 +70,18 @@ function Add-ManagedFilesFromDir {
 function Build-ManagedFilesMap {
     param(
         [string]$baseDir,
-        [string]$overlay,
+        [string[]]$overlays,
         [string[]]$excluded,
         [string]$repoId
     )
 
     $rootDir = Join-Path $baseDir "root"
-    $overlayDir = ""
-    if ($overlay -ne "") {
-        $overlayDir = Join-Path $baseDir $overlay
-    }
 
     $map = @{}
     Add-ManagedFilesFromDir -baseDir $rootDir -map $map
-    if ($overlayDir -ne "") {
-        Add-ManagedFilesFromDir -baseDir $overlayDir -map $map
+    foreach ($overlay in @($overlays)) {
+        if ([string]::IsNullOrWhiteSpace($overlay)) { continue }
+        Add-ManagedFilesFromDir -baseDir (Join-Path $baseDir $overlay) -map $map
     }
 
     foreach ($excludedPath in $excluded) {
@@ -94,7 +91,7 @@ function Build-ManagedFilesMap {
         }
     }
 
-    Write-Host "Resolved $($map.Count) managed file(s) for repository '$repoId' (overlay='$overlay', exclusions=$($excluded.Count))."
+    Write-Host "Resolved $($map.Count) managed file(s) for repository '$repoId' (overlays='$(@($overlays) -join ", ")', exclusions=$($excluded.Count))."
 
     return $map
 }

--- a/tf-repo-mgmt/scripts/lib/RepositoryConfig.ps1
+++ b/tf-repo-mgmt/scripts/lib/RepositoryConfig.ps1
@@ -58,22 +58,18 @@ function Resolve-RepositorySettings {
     }
     $repositoryTopics = @($repositoryTopics | Select-Object -Unique)
 
-    # Collect the managed-files overlay set declared on any matching
-    # repository group (e.g. `alz` for the azure-landing-zones group). At
-    # most one distinct value is allowed; conflicting overlays across groups
-    # for the same repo are a configuration error.
-    $managedFilesAdditionalValues = @()
+    # Collect the managed-files overlay sets declared on any matching
+    # repository group (e.g. `alz` for the azure-landing-zones group).
+    # Overlays stack: they are applied over `managed-files/root` in the order
+    # the groups are declared in config.json, so a later group's file wins for
+    # any path an earlier overlay (or root) also provides.
+    $managedFilesAdditional = @()
     foreach ($repositoryGroup in $repositoryGroups) {
         if ($repositoryGroup.PSObject.Properties.Name -contains "managedFilesAdditional" -and $repositoryGroup.managedFilesAdditional) {
-            $managedFilesAdditionalValues += $repositoryGroup.managedFilesAdditional
+            $managedFilesAdditional += $repositoryGroup.managedFilesAdditional
         }
     }
-    $managedFilesAdditionalValues = @($managedFilesAdditionalValues | Select-Object -Unique)
-    if ($managedFilesAdditionalValues.Count -gt 1) {
-        Write-Error "Repository '$repoId' belongs to multiple repository groups that declare conflicting 'managedFilesAdditional' overlay sets: $($managedFilesAdditionalValues -join ', '). At most one is allowed."
-        exit 1
-    }
-    $managedFilesAdditional = if ($managedFilesAdditionalValues.Count -eq 1) { $managedFilesAdditionalValues[0] } else { "" }
+    $managedFilesAdditional = @($managedFilesAdditional | Select-Object -Unique)
 
     # Collect the set of managed files to exclude from the final map for
     # this repository. Excluded files are pulled in from every matching

--- a/tf-repo-mgmt/scripts/lib/RepositoryConfig.ps1
+++ b/tf-repo-mgmt/scripts/lib/RepositoryConfig.ps1
@@ -58,18 +58,36 @@ function Resolve-RepositorySettings {
     }
     $repositoryTopics = @($repositoryTopics | Select-Object -Unique)
 
-    # Collect the managed-files overlay sets declared on any matching
-    # repository group (e.g. `alz` for the azure-landing-zones group).
-    # Overlays stack: they are applied over `managed-files/root` in the order
-    # the groups are declared in config.json, so a later group's file wins for
-    # any path an earlier overlay (or root) also provides.
-    $managedFilesAdditional = @()
+    # Collect and order the managed-files overlay sets declared on any matching
+    # repository group (e.g. `alz` for the azure-landing-zones group). Lower
+    # orders are applied first, so a higher-order overlay wins for duplicate
+    # paths. This ordering is mirrored in Avm.Authoring's
+    # Sync-AvmManagedFile.ps1 and the two implementations must not diverge.
+    $overlayEntries = @()
+    $declarationIndex = 0
     foreach ($repositoryGroup in $repositoryGroups) {
-        if ($repositoryGroup.PSObject.Properties.Name -contains "managedFilesAdditional" -and $repositoryGroup.managedFilesAdditional) {
-            $managedFilesAdditional += $repositoryGroup.managedFilesAdditional
+        if ($repositoryGroup.PSObject.Properties.Name -contains 'managedFilesAdditional' -and $repositoryGroup.managedFilesAdditional) {
+            $order = 0
+            if ($repositoryGroup.PSObject.Properties.Name -contains 'managedFilesOrder' -and $null -ne $repositoryGroup.managedFilesOrder) {
+                $order = [int] $repositoryGroup.managedFilesOrder
+            }
+            foreach ($overlay in @($repositoryGroup.managedFilesAdditional)) {
+                $overlayEntries += [pscustomobject]@{
+                    Overlay = $overlay
+                    Order   = $order
+                    Index   = $declarationIndex
+                }
+            }
         }
+        $declarationIndex++
     }
-    $managedFilesAdditional = @($managedFilesAdditional | Select-Object -Unique)
+
+    $managedFilesAdditional = @(
+        $overlayEntries |
+            Sort-Object -Property Order, Index |
+            Select-Object -ExpandProperty Overlay |
+            Select-Object -Unique
+    )
 
     # Collect the set of managed files to exclude from the final map for
     # this repository. Excluded files are pulled in from every matching

--- a/tf-repo-mgmt/scripts/lib/RepositoryConfig.ps1
+++ b/tf-repo-mgmt/scripts/lib/RepositoryConfig.ps1
@@ -103,14 +103,65 @@ function Resolve-RepositorySettings {
     }
     $excludedManagedFiles = @($excludedManagedFiles | Select-Object -Unique)
 
+    # Workload identity federation subject-claim overrides. The Azure federated
+    # identity credential subject pins `job_workflow_ref` to the governance
+    # managed-pr-check workflow by default; repositories piloting a different
+    # reusable workflow must override it or OIDC token exchange fails.
+    #
+    # Merged per key across every group containing the repo, using the same
+    # (managedFilesOrder, declaration index) precedence as managed-files
+    # overlays: higher order wins.
+    $supportedClaimOverrides = @{
+        jobWorkflowRef = "github_job_workflow_ref"
+    }
+
+    $claimOverrideEntries = @()
+    $claimDeclarationIndex = 0
+    foreach ($repositoryGroup in $repositoryGroups) {
+        if ($repositoryGroup.PSObject.Properties.Name -contains "workloadIdentityFederationSubjectClaimOverrides" -and $repositoryGroup.workloadIdentityFederationSubjectClaimOverrides) {
+            $order = 0
+            if ($repositoryGroup.PSObject.Properties.Name -contains "managedFilesOrder" -and $null -ne $repositoryGroup.managedFilesOrder) {
+                $order = [int]$repositoryGroup.managedFilesOrder
+            }
+            foreach ($claimOverride in $repositoryGroup.workloadIdentityFederationSubjectClaimOverrides.PSObject.Properties) {
+                if (-not $supportedClaimOverrides.ContainsKey($claimOverride.Name)) {
+                    throw "Repository group '$($repositoryGroup.name)' sets unsupported workloadIdentityFederationSubjectClaimOverrides key '$($claimOverride.Name)'. Supported keys: $($supportedClaimOverrides.Keys -join ', ')."
+                }
+                $claimOverrideEntries += [pscustomobject]@{
+                    Claim = $claimOverride.Name
+                    Value = $claimOverride.Value
+                    Order = $order
+                    Index = $claimDeclarationIndex
+                }
+            }
+        }
+        $claimDeclarationIndex++
+    }
+
+    $workloadIdentityFederationSubjectClaimOverrides = @{}
+    foreach ($claimOverrideEntry in ($claimOverrideEntries | Sort-Object -Property Order, Index)) {
+        $workloadIdentityFederationSubjectClaimOverrides[$claimOverrideEntry.Claim] = $claimOverrideEntry.Value
+    }
+
+    # A job_workflow_ref claim always carries a fully-qualified git ref
+    # (refs/heads/..., refs/tags/...) or a full commit SHA, even though `uses:`
+    # is normally written as `@main`. Fail here rather than at OIDC exchange.
+    if ($workloadIdentityFederationSubjectClaimOverrides.ContainsKey("jobWorkflowRef")) {
+        $jobWorkflowRefOverride = $workloadIdentityFederationSubjectClaimOverrides["jobWorkflowRef"]
+        if ($jobWorkflowRefOverride -notmatch "@(refs/.+|[0-9a-fA-F]{40})$") {
+            throw "workloadIdentityFederationSubjectClaimOverrides.jobWorkflowRef must end with a fully-qualified ref (for example '@refs/heads/main') or a full commit SHA, but was '$jobWorkflowRefOverride'."
+        }
+    }
+
     return @{
-        RepositoryGroups              = $repositoryGroups
-        RepositoryGroupNames          = $repositoryGroupNames
-        Teams                         = $teams
-        CodeOwnersDefaultTeams        = $codeOwnersDefaultTeams
-        CodeOwnersFileProtectionTeams = $codeOwnersFileProtectionTeams
-        Topics                        = $repositoryTopics
-        ManagedFilesAdditional        = $managedFilesAdditional
-        ExcludedManagedFiles          = $excludedManagedFiles
+        RepositoryGroups                                = $repositoryGroups
+        RepositoryGroupNames                            = $repositoryGroupNames
+        Teams                                           = $teams
+        CodeOwnersDefaultTeams                          = $codeOwnersDefaultTeams
+        CodeOwnersFileProtectionTeams                   = $codeOwnersFileProtectionTeams
+        Topics                                          = $repositoryTopics
+        ManagedFilesAdditional                          = $managedFilesAdditional
+        ExcludedManagedFiles                            = $excludedManagedFiles
+        WorkloadIdentityFederationSubjectClaimOverrides = $workloadIdentityFederationSubjectClaimOverrides
     }
 }


### PR DESCRIPTION
## Summary

- enable managed-files overlays to stack in repository-group declaration order, allowing the existing `canary` overlay to be combined with a later, more specific tooling overlay
- add the `canary-tooling` cohort containing only `avm-ptn-example-repo` to trial the PowerShell Gallery based toolchain end to end
- override `pr-check.yml` so the canary calls `Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@main`
- replace `avm`, `avm.bat`, and `avm.ps1` with deliberately failing deprecation stubs so the old container/make path cannot be invoked in the canary repository

## Reviewer note

Any fleet-wide governance workflow that shells out to `./avm`, including `dependabot-precommit.yml` and `pre-commit-cron.yml`, will now fail for `terraform-azurerm-avm-ptn-example-repo`. This is expected for the canary, but reviewers should be aware of the impact.

## Verification

- resolved `avm-ptn-example-repo` overlays as `canary, canary-tooling` in that order
- confirmed `pr-check.yml`, `avm`, `avm.ps1`, and `avm.bat` resolve from `managed-files/canary-tooling`
- confirmed the resolved `avm` mode is `100755`
- confirmed `avm-ptn-alz` still resolves its single `alz` overlay and `avm-ptn-monitoring-amba-alz` resolves no overlays
- confirmed all three launcher stubs write guidance only to stderr and exit with code 1