### PR TITLE
feat(canary): add per-repo Dependabot pre-commit workflow

### DIFF
--- a/managed-files/canary/.github/workflows/dependabot-precommit.yml
+++ b/managed-files/canary/.github/workflows/dependabot-precommit.yml
@@ -1,0 +1,52 @@
+---
+name: Dependabot Pre-Commit
+
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+
+# Dependabot-triggered runs get a read-only GITHUB_TOKEN by default; declaring
+# permissions explicitly is the supported way to lift that so we can push.
+permissions:
+  contents: write
+
+jobs:
+  pre-commit:
+    name: Apply Pre-Commit Fixes
+    # Only Terraform bumps leave generated files (README version tables,
+    # formatting) stale. github_actions bumps produce no pre-commit diff.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/terraform/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Run pre-commit
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod a+x ./avm
+          # pre-commit exits non-zero when it rewrites files, so run again to verify.
+          ./avm pre-commit
+          if ($LASTEXITCODE -ne 0) {
+            ./avm pre-commit
+          }
+
+      - name: Commit and push pre-commit fixes
+        shell: pwsh
+        run: |
+          if (-not (git status --porcelain)) {
+            Write-Host "No pre-commit changes to push."
+            exit 0
+          }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore(deps): apply pre-commit fixes"
+          git push


### PR DESCRIPTION
## Summary

Adds `managed-files/canary/.github/workflows/dependabot-precommit.yml` — a per-repo workflow that runs `./avm pre-commit` on Dependabot Terraform PRs from inside the target repo and pushes the fixes straight back to the Dependabot branch.

Scoped to the **canary** repository group only (9 repos) via the existing `managedFilesAdditional: "canary"` overlay. No config changes needed.

## Why

Today a Dependabot Terraform bump lands with stale generated files (README version tables, formatting). The flow is:

1. PR opens
2. A human approves `pr_check`, `integration_test`, `examples_test` environments
3. Full PR check runs — including example deployments against real Azure subscriptions
4. Fails on stale docs
5. Waits until the Monday cron (`.github/workflows/dependabot-precommit.yml`) pushes fixes
6. Human approves the environments **again**
7. Passes

Step 3 is an entire integration-test and example-deployment run burned for nothing.

With this workflow:

1. PR opens
2. Pre-commit workflow fixes the branch in seconds — no environment, no approval gate
3. Human clicks "Approve workflows to run", approves the environments **once**
4. Passes

It also avoids `dismiss_stale_reviews_on_push` silently dropping an approval when the cron pushes to an already-reviewed PR.

## Design notes

- **No secrets required.** `./avm pre-commit` pulls the public `mcr.microsoft.com/azterraform:avm-latest` image and needs no Azure credentials — only `GITHUB_TOKEN`. This removes a consumer of `AVM_APP_PRIVATE_KEY`.
- **Rulesets are not a blocker.** The "Azure Verified Modules" ruleset targets `~DEFAULT_BRANCH` only, so `dependabot/**` branches are unprotected and can be pushed to directly. No PR needed.
- **`permissions: contents: write` at workflow level.** Dependabot-triggered runs get a read-only `GITHUB_TOKEN` by default; an explicit `permissions` block is the documented way to lift it. Kept at workflow level (rather than `permissions: {}` + job-level, as in `codeql.yml`) to match GitHub's documented Dependabot guidance on the one thing this design hinges on.
- **Branch-prefix filter, not label.** Guards on `startsWith(head.ref, 'dependabot/terraform/')` rather than the `Language: Terraform` label, which may not be attached yet at `opened` time. Verified against live PRs that this is the real prefix.
- **Recursion is safe.** The push re-triggers `synchronize`; the second run finds no diff and exits. The same "Approve workflows to run" click releases both.
- `shell: pwsh` throughout, per repo scripting convention.

## Verification

`Build-ManagedFilesMap` dry-run:

| Overlay | Files resolved | Includes workflow |
| --- | --- | --- |
| `canary` | 40 | ✅ |
| _(none)_ | 39 | ❌ |

File mode is `100644` in the git index; `.gitkeep` still filtered out of sync.

## Deliberately out of scope

- **The centralised `.github/workflows/dependabot-precommit.yml` stays.** For `pull_request`, the workflow file is read from the PR head branch — the ~115 currently-open Dependabot PRs branched before this file existed and can't run it until rebased. Keep the cron until canary proves out and the backlog drains.
- **No `concurrency` on `pr-check.yml`.** After the fix push there will be two queued runs (stale commit + new). Both sit unapproved so cost is nil, just noisy UI. Follow-up.
- **Not rolled out to `managed-files/root`.** Canary first.

## What to watch on canary

Whether the job actually receives `contents: write` on a Dependabot-triggered run. That's the one unproven assumption — if the push 403s, the fallback is a GitHub App token, which reintroduces the credential this change removes.

## Docs

Once this graduates from canary, the AVM contributor docs describing the Dependabot flow will need updating in `Azure-Verified-Modules-Docs`. Not raised yet — better folded into whatever is open at that point.