### PR TITLE
fix(tf-repo-mgmt): break stale state blob leases when force-unlock cannot

### DIFF
--- a/.github/workflows/tf-repo-mgmt.yml
+++ b/.github/workflows/tf-repo-mgmt.yml
@@ -40,6 +40,13 @@ permissions:
   id-token: write
   contents: read
 
+# Each repo's Terraform state is a single blob, and a cancelled run leaves its
+# lease behind. Queue overlapping runs rather than cancelling them, so the sync
+# stays the only writer and any lock it does find is genuinely stale.
+concurrency:
+  group: repository-sync
+  cancel-in-progress: false
+
 env:
   # The GitHub Project (ProjectV2) that every AVM Terraform repo's issues and PRs
   # are synced into ("AVM All Up"). A central, fixed target, so it lives here as a
@@ -99,6 +106,16 @@ jobs:
           client-id: ${{ secrets.AVM_APP_CLIENT_ID }}
           private-key: ${{ secrets.AVM_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+
+      # Terraform authenticates on its own via the ARM_* variables below. The
+      # Azure CLI needs its own login so state lock recovery can break the
+      # lease on a state blob left locked by a cancelled run.
+      - name: Azure Login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: Download Labels CSV File
         run: |

--- a/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
+++ b/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
@@ -230,6 +230,8 @@ $issueLog = Invoke-TerraformPlanAndApply `
     -orgAndRepoName $orgAndRepoName `
     -planOnly $planOnly `
     -resourceTypesThatCannotBeDestroyed $resourceTypesThatCannotBeDestroyed `
+    -stateStorageAccountName $stateStorageAccountName `
+    -stateContainerName $stateContainerName `
     -issueLog $issueLog
 
 # Sync managed files via a single clone -> branch -> PR -> merge flow.

--- a/tf-repo-mgmt/scripts/lib/RetryHelpers.ps1
+++ b/tf-repo-mgmt/scripts/lib/RetryHelpers.ps1
@@ -14,6 +14,9 @@ function Invoke-TerraformWithRetry {
         [int]$maxRetries = 50,
         [int]$retryDelayIncremental = 10,
         [string[]]$retryOn = @("429 Too Many Requests", "Client.Timeout exceeded while awaiting headers", "Error: Failed to install provider", "Error: Failed to query available provider packages", "403 API rate limit"),
+        [string]$stateStorageAccountName,
+        [string]$stateContainerName,
+        [string]$stateBlobName,
         [switch]$printOutput,
         [switch]$printOutputOnError,
         [switch]$returnOutputParsedFromJson
@@ -32,12 +35,22 @@ function Invoke-TerraformWithRetry {
     $recoveryActions = @(
         @{
             Name        = "terraform state lock"
-            Pattern     = "Error acquiring the state lock"
+            Pattern     = @("Error acquiring the state lock", "Error releasing the state lock")
             MaxAttempts = 3
-            Context     = @{ workingDirectory = $workingDirectory }
+            Context     = @{
+                workingDirectory   = $workingDirectory
+                storageAccountName = $stateStorageAccountName
+                containerName      = $stateContainerName
+                blobName           = $stateBlobName
+            }
             Action      = {
                 param([string[]]$errorOutput, [hashtable]$context)
-                Clear-TerraformStateLock -errorOutput $errorOutput -workingDirectory $context.workingDirectory
+                Clear-TerraformStateLock `
+                    -errorOutput $errorOutput `
+                    -workingDirectory $context.workingDirectory `
+                    -storageAccountName $context.storageAccountName `
+                    -containerName $context.containerName `
+                    -blobName $context.blobName
             }
         }
     )
@@ -56,14 +69,21 @@ function Invoke-TerraformWithRetry {
         -returnOutputParsedFromJson:$returnOutputParsedFromJson.IsPresent
 }
 
-# Parses the lock ID out of a Terraform "Error acquiring the state lock"
-# message and releases it with `terraform force-unlock`. Returns $true only
-# when the lock was actually released, so the caller can fall through to the
-# normal failure path when the lock cannot be parsed or broken.
+# Clears the state lock left behind by a cancelled or crashed run. Prefers
+# `terraform force-unlock`, which clears the lock metadata as well as the blob
+# lease, and falls back to breaking the lease directly. The fallback matters
+# because a killed run often leaves the lease held with an empty
+# "terraformlockid" metadata value: there is then no ID for force-unlock to
+# match, and breaking the lease is the only way to release the blob. Returns
+# $true only when the lock was actually released, so the caller can fall
+# through to the normal failure path when it cannot be broken.
 function Clear-TerraformStateLock {
     param(
         [string[]]$errorOutput,
         [string]$workingDirectory,
+        [string]$storageAccountName,
+        [string]$containerName,
+        [string]$blobName,
         [string]$outputLog = "force-unlock.log",
         [string]$errorLog = "force-unlock.error.log"
     )
@@ -81,16 +101,65 @@ function Clear-TerraformStateLock {
         }
     }
 
-    if (!$lockId) {
-        Write-Warning "Could not parse a Terraform state lock ID from the error output. Leaving the lock in place."
+    if ($lockId) {
+        Write-Host "Found stale Terraform state lock '$lockId'. Forcing unlock."
+
+        $process = Start-Process `
+            -FilePath "terraform" `
+            -ArgumentList @("-chdir=$workingDirectory", "force-unlock", "-force", $lockId) `
+            -RedirectStandardOutput $outputLog `
+            -RedirectStandardError $errorLog `
+            -PassThru `
+            -NoNewWindow `
+            -Wait
+
+        if ($process.ExitCode -eq 0) {
+            Write-Host "Released Terraform state lock '$lockId'."
+            return $true
+        }
+
+        Write-Warning "terraform force-unlock failed with exit code $($process.ExitCode). Falling back to breaking the state blob lease."
+        Get-Content -Path $errorLog | Write-Host
+    }
+    else {
+        Write-Host "No Terraform state lock ID in the error output. Falling back to breaking the state blob lease."
+    }
+
+    return Clear-TerraformStateBlobLease `
+        -storageAccountName $storageAccountName `
+        -containerName $containerName `
+        -blobName $blobName
+}
+
+# Breaks the Azure Storage blob lease that backs a Terraform state lock. Used
+# when `terraform force-unlock` cannot help, either because the lock metadata
+# is empty or because the lease no longer matches the one Terraform holds.
+function Clear-TerraformStateBlobLease {
+    param(
+        [string]$storageAccountName,
+        [string]$containerName,
+        [string]$blobName,
+        [string]$outputLog = "lease-break.log",
+        [string]$errorLog = "lease-break.error.log"
+    )
+
+    if (!$storageAccountName -or !$containerName -or !$blobName) {
+        Write-Warning "No state blob details were supplied, so the state lock cannot be broken. Leaving the lock in place."
         return $false
     }
 
-    Write-Host "Found stale Terraform state lock '$lockId'. Forcing unlock."
+    Write-Host "Breaking the lease on state blob '$blobName' in '$storageAccountName/$containerName'."
 
     $process = Start-Process `
-        -FilePath "terraform" `
-        -ArgumentList @("-chdir=$workingDirectory", "force-unlock", "-force", $lockId) `
+        -FilePath "az" `
+        -ArgumentList @(
+            "storage", "blob", "lease", "break",
+            "--account-name", $storageAccountName,
+            "--container-name", $containerName,
+            "--blob-name", $blobName,
+            "--lease-break-period", "0",
+            "--auth-mode", "login"
+        ) `
         -RedirectStandardOutput $outputLog `
         -RedirectStandardError $errorLog `
         -PassThru `
@@ -98,12 +167,12 @@ function Clear-TerraformStateLock {
         -Wait
 
     if ($process.ExitCode -ne 0) {
-        Write-Warning "terraform force-unlock failed with exit code $($process.ExitCode)."
+        Write-Warning "Breaking the lease on state blob '$blobName' failed with exit code $($process.ExitCode)."
         Get-Content -Path $errorLog | Write-Host
         return $false
     }
 
-    Write-Host "Released Terraform state lock '$lockId'."
+    Write-Host "Broke the lease on state blob '$blobName'."
     return $true
 }
 
@@ -197,7 +266,14 @@ function Invoke-CommandWithRetry {
                 # when the action reports that it actually fixed the problem.
                 if (!$shouldRetry) {
                     foreach ($recovery in $recoveryActions) {
-                        if (!($errorOutput | Where-Object { $_ -like "*$($recovery.Pattern)*" })) {
+                        $matchedPattern = $false
+                        foreach ($pattern in @($recovery.Pattern)) {
+                            if ($errorOutput | Where-Object { $_ -like "*$pattern*" }) {
+                                $matchedPattern = $true
+                                break
+                            }
+                        }
+                        if (!$matchedPattern) {
                             continue
                         }
 

--- a/tf-repo-mgmt/scripts/lib/TerraformOperations.ps1
+++ b/tf-repo-mgmt/scripts/lib/TerraformOperations.ps1
@@ -70,6 +70,9 @@ terraform {
                 }
             ) `
             -workingDirectory $terraformModulePath `
+            -stateStorageAccountName $stateStorageAccountName `
+            -stateContainerName $stateContainerName `
+            -stateBlobName "$($repoId).tfstate" `
             -printOutput
     }
 
@@ -92,6 +95,8 @@ function Invoke-TerraformPlanAndApply {
         [string]$orgAndRepoName,
         [bool]$planOnly,
         [string[]]$resourceTypesThatCannotBeDestroyed,
+        [string]$stateStorageAccountName,
+        [string]$stateContainerName,
         [array]$issueLog
     )
 
@@ -103,6 +108,9 @@ function Invoke-TerraformPlanAndApply {
             }
         ) `
         -workingDirectory $terraformModulePath `
+        -stateStorageAccountName $stateStorageAccountName `
+        -stateContainerName $stateContainerName `
+        -stateBlobName "$($repoId).tfstate" `
         -printOutput
 
     if (!$result.success) {
@@ -152,6 +160,9 @@ function Invoke-TerraformPlanAndApply {
                 }
             ) `
             -workingDirectory $terraformModulePath `
+            -stateStorageAccountName $stateStorageAccountName `
+            -stateContainerName $stateContainerName `
+            -stateBlobName "$($repoId).tfstate" `
             -printOutput `
             -maxRetries 0
 
@@ -169,6 +180,9 @@ function Invoke-TerraformPlanAndApply {
                     }
                 ) `
                 -workingDirectory $terraformModulePath `
+                -stateStorageAccountName $stateStorageAccountName `
+                -stateContainerName $stateContainerName `
+                -stateBlobName "$($repoId).tfstate" `
                 -printOutput
         }
 


### PR DESCRIPTION
## Problem

The scheduled sync has been failing on the same three repos every run
(`avm-res-network-expressrouteport`, `avm-res-sql-instancepool`,
`avm-res-storage-storageaccount`), and #528 / #532 did not fix it.

The state blobs hold an **orphaned Azure blob lease whose `terraformlockid`
metadata is empty**:

```
Error: Error acquiring the state lock
Error message: state blob is already locked
blob metadata "terraformlockid" was empty
```

`terraform force-unlock <id>` structurally cannot clear this. The azurerm
backend's `Unlock` reads the lock metadata first and then compares it to the
ID you passed — with empty metadata there is no ID to parse and nothing that
can ever match. The recovery hook added in #528 correctly reported
"Could not parse a Terraform state lock ID" and gave up.

`expressrouteport` shows the sibling symptom of the same lease:

```
Error: Error releasing the state lock
Error message: failed to retrieve lock info: ... 412 (The lease ID specified
did not match the lease ID for the blob.)
```

Breaking the lease is the only thing that clears either — which is exactly
what the `unlock-state-blobs.yml` workflow removed in #528 did by hand.

## Change

Keep force-unlock as the graceful path, add a lease break as the fallback.

- `Clear-TerraformStateLock` now falls through to a new
  `Clear-TerraformStateBlobLease` when no lock ID can be parsed **or** when
  force-unlock fails. The lease break is
  `az storage blob lease break --lease-break-period 0 --auth-mode login`.
- Recovery triggers on `Error releasing the state lock` as well as
  `Error acquiring the state lock`; `Pattern` now accepts an array.
- Storage account / container / blob name are plumbed through init, plan and
  apply so the fallback knows which blob to act on. Repository *creation* uses
  a local backend and passes nothing, so the guard short-circuits there.
- `azure/login` (OIDC) added to the sync job — only Terraform was
  authenticated, via `ARM_*` env vars; the Azure CLI had no credentials.
- `concurrency: repository-sync` with `cancel-in-progress: false`, so runs
  queue instead of overlapping. A cancelled run mid-apply is how these leases
  get orphaned, and queueing is what makes "any lock we find is stale"
  actually true.

Breaking the lease is safe to do unconditionally: the azurerm backend takes
the lease *before* writing lock metadata, so the next successful acquire
overwrites whatever stale metadata is left behind.

## Testing

Local harness driving the workflow's real invocation chain
(`pwsh -command ". '<step>'"` -> `Invoke-RepositorySync.ps1` -> dot-sourced
lib) with compiled `terraform.exe` / `az.exe` stubs. 9 cases covering: lock ID
present and force-unlock succeeds; empty metadata falling back to lease break;
release-lock 412; force-unlock failing then lease break succeeding; lease break
failing; missing blob details; retry-count arithmetic; and the pre-existing
non-state-lock retry paths.

The 5 new cases fail against `main` and pass here. The 4 pre-existing cases
pass on both. PSScriptAnalyzer reports no new violations.

The one thing that cannot be proven locally is whether the lease break
succeeds against these particular blobs in production — worth watching the
first scheduled run after merge.
