### PR TITLE
docs(skills): move the AVM Terraform skill onto the Avm.Authoring module

### DIFF
--- a/managed-files/root/.agents/skills/avm-terraform-module-development/SKILL.md
+++ b/managed-files/root/.agents/skills/avm-terraform-module-development/SKILL.md
@@ -75,7 +75,7 @@ For full AzAPI patterns, the `parent_id` variable shape, the `Get-AzureSchema` l
 - `TFFR3` / `TFNFR26` — Pin `required_providers` versions (`Azure/azapi`, `Azure/modtm`, `hashicorp/random`, any other providers used) in the single `terraform {}` block in `terraform.tf`. AzAPI version policy is governed by `TFFR3`.
 - `TFNFR27` — No provider configuration blocks in modules (only `required_providers`). Provider configuration belongs in the consumer's root module.
 
-The `mapotf` pre-commit config under [mapotf-configs/pre-commit](../../../../../mapotf-configs/pre-commit/) enforces the telemetry block and provider versions automatically — do not hand-edit those generated files.
+The `mapotf` pre-commit configs enforce the telemetry block and provider versions automatically — do not hand-edit the files they generate. The configs ship inside the `Avm.Authoring` module and are applied by `avm transform` (which `avm pre-commit` runs for you); a repository may override them by committing its own `config/mapotf/pre-commit/` directory.
 
 ### Standard interfaces
 
@@ -96,16 +96,29 @@ For a single concise summary of how a resource or pattern module fits together (
 
 Follow these steps in order when fixing an issue or adding a feature.
 
+### Step 0: Load the AVM toolchain
+
+Every `avm` command below comes from the `Avm.Authoring` PowerShell module. Install it once, then import it in each PowerShell session:
+
+```pwsh
+Install-PSResource -Name Avm.Authoring -Repository PSGallery -TrustRepository
+Import-Module Avm.Authoring
+```
+
+The module downloads and pins the tools it needs (terraform, tflint, terraform-docs, conftest, mapotf) on first use, so there is no separate install step. Set `AVM_NO_AUTO_INSTALL=1` in air-gapped environments and pre-warm the cache with `avm tool install <name>` instead.
+
+The repository-root `./avm`, `avm.bat`, and `avm.ps1` launchers are **deprecated** and exit with an error. Do not use them, and do not set `PORCH_NO_TUI`.
+
 ### Step 1: Start from a clean main branch
 
-```bash
+```pwsh
 git checkout main
 git pull
 ```
 
 ### Step 2: Create and checkout a feature/issue branch
 
-```bash
+```pwsh
 git checkout -b feature/<short-description>
 # or
 git checkout -b fix/<issue-number>-<short-description>
@@ -121,24 +134,26 @@ For AzAPI resource patterns, schema lookups, and the `Get-AzureSchema` CLI tool,
 
 Unit tests use **provider mocking** and live in the `tests/unit` directory. Add or update unit tests when your change introduces new logic, variables, or outputs that can be validated without deploying real infrastructure. For test writing guidance, syntax, and patterns, read [terraform-test.md](references/terraform-test.md).
 
-```bash
-PORCH_NO_TUI=1 ./avm tf-test-unit
+```pwsh
+avm test unit
 ```
 
 ### Step 5: Add integration tests (if justified)
 
 Integration tests do **not** use provider mocking and live in the `tests/integration` directory. Add or update integration tests when your change requires validation against real Azure infrastructure. For test writing guidance, syntax, and patterns, read [terraform-test.md](references/terraform-test.md).
 
-```bash
-PORCH_NO_TUI=1 ./avm tf-test-integration
+```pwsh
+avm test integration
 ```
 
 ### Step 6: Add or update examples (if justified)
 
-If your change affects module usage or introduces new functionality, add or update examples in the `examples/` directory. Test only the pertinent example:
+If your change affects module usage or introduces new functionality, add or update examples in the `examples/` directory.
 
-```bash
-PORCH_NO_TUI=1 AVM_EXAMPLE="<ExampleDir>" ./avm test-examples
+`avm test e2e` deploys, idempotency-checks, and destroys **every** example under `examples/`. It creates real Azure infrastructure, so it is normally left to CI. Drop a `.e2eignore` marker file into an example directory to exclude it.
+
+```pwsh
+avm test e2e
 ```
 
 When running on Windows, distributing tests across multiple Azure subscriptions, or retaining deployed resources for manual validation, see [example-test.md](references/example-test.md) for manual local testing of examples (init, plan, apply, idempotency check, and optional destroy).
@@ -151,13 +166,13 @@ If documentation changes are needed, edit `_header.md`. **NEVER edit README.md d
 
 This must **always** be run before committing:
 
-```bash
-PORCH_NO_TUI=1 ./avm pre-commit
+```pwsh
+avm pre-commit
 ```
 
 ### Step 9: Commit changes
 
-```bash
+```pwsh
 git add .
 git commit -m "<type>: <meaningful description>"
 ```
@@ -166,15 +181,15 @@ git commit -m "<type>: <meaningful description>"
 
 This must **always** be run after committing:
 
-```bash
-PORCH_NO_TUI=1 ./avm pr-check
+```pwsh
+avm pr-check
 ```
 
 ### Step 11: Push and open a PR
 
 Push the branch to remote and open a pull request with a meaningful description. Reference any issues that should be closed.
 
-```bash
+```pwsh
 git push -u origin HEAD
 ```
 
@@ -201,7 +216,7 @@ When creating the PR, include:
 - **Using the legacy `diagnostic_settings` shape** instead of the v2 schema. The utility module's `diagnostic_settings_v2` input is the required entry point.
 - **Omitting `retry`, `timeouts`, or `resource_types` from an `azapi_resource`** — or failing to cascade them unchanged into submodules. All three are MUST-level AVM interfaces.
 - **Treating `timeouts` as an attribute.** It is a block; use `dynamic "timeouts"` so the `null` default works.
-- **Skipping `./avm pre-commit` before commit, or `./avm pr-check` after commit.** Both are mandatory.
+- **Skipping `avm pre-commit` before commit, or `avm pr-check` after commit.** Both are mandatory.
 
 ## Specifications
 

--- a/managed-files/root/.agents/skills/avm-terraform-module-development/references/terraform-test.md
+++ b/managed-files/root/.agents/skills/avm-terraform-module-development/references/terraform-test.md
@@ -28,7 +28,7 @@ Submodules under `./modules/` follow the same pattern — each can have its own 
 | **Command** | `command = apply` (safe with mocks) | `command = apply` (default) |
 | **Speed** | Fast (seconds) | Slow (minutes) |
 | **Credentials needed** | No | Yes (Azure) |
-| **Run command** | `PORCH_NO_TUI=1 ./avm tf-test-unit` | `PORCH_NO_TUI=1 ./avm tf-test-integration` |
+| **Run command** | `avm test unit` | `avm test integration` |
 
 **Critical rule**: Unit tests use `command = apply` (NOT `command = plan`) because mocked providers make apply safe and allow testing resource creation logic.
 
@@ -355,25 +355,25 @@ run "test_module_b" {
 
 ### Optional Setup Script
 
-If `tests/unit/setup.sh` or `tests/integration/setup.sh` exists, it runs automatically before `terraform init`. Use this for environment preparation.
+If `tests/unit/setup.ps1` or `tests/integration/setup.ps1` exists, it runs automatically before `terraform init`. Use this for environment preparation. Shell hooks (`setup.sh`, `teardown.sh`) are **not** supported and cause the run to fail fast — port them to PowerShell.
 
 ## Running Tests
 
-Tests run inside the AVM container via the `./avm` wrapper. Always prefix with `PORCH_NO_TUI=1`.
+Tests run via the `Avm.Authoring` PowerShell module. Import it once per session (`Import-Module Avm.Authoring`); it acquires the pinned `terraform` binary on first use.
 
-```bash
+```pwsh
 # Unit tests
-PORCH_NO_TUI=1 ./avm tf-test-unit
+avm test unit
 
 # Integration tests
-PORCH_NO_TUI=1 ./avm tf-test-integration
+avm test integration
 ```
 
 The test runner automatically:
 1. Checks that `tests/unit/` or `tests/integration/` exists (skips gracefully if not)
 2. Copies the working directory to a temp location
 3. Cleans `.terraform`, lock files, and state files
-4. Runs `setup.sh` if present
+4. Runs `setup.ps1` if present
 5. Runs `terraform init -test-directory ./tests/<type>`
 6. Runs `terraform test -test-directory ./tests/<type>`
 7. Repeats for each submodule under `./modules/` (in parallel)
@@ -383,7 +383,7 @@ The test runner automatically:
 
 Resources created by integration tests are destroyed automatically in **reverse run block order** after test completion. This handles dependency ordering correctly.
 
-For debugging, the `terraform test -no-cleanup` flag prevents automatic destruction — but note that this must be run directly, not via `./avm`.
+For debugging, the `terraform test -no-cleanup` flag prevents automatic destruction — but note that this must be run against `terraform` directly, not via `avm test`.
 
 ## Best Practices
 


### PR DESCRIPTION
## What

The AVM Terraform development skill (and its `terraform-test` reference) still
instructs agents to run `PORCH_NO_TUI=1 ./avm <verb>`. Those launchers
(`avm`, `avm.bat`, `avm.ps1`) are deprecated and now hard-exit, so every
command in the skill is unrunnable as written. The supported entry point is the
`Avm.Authoring` PowerShell module.

Reported as **F10** in the `Avm.Authoring` 0.1.4 end-to-end review.

## Changes

`managed-files/root/.agents/skills/avm-terraform-module-development/SKILL.md`

- New **Step 0 - Load the AVM toolchain**: `Install-PSResource -Name Avm.Authoring`
  + `Import-Module Avm.Authoring`. Notes that pinned tools (terraform, tflint,
  terraform-docs, conftest, mapotf) are installed automatically on first use, and
  documents `AVM_NO_AUTO_INSTALL=1` + `avm tool install <name>` for air-gapped
  environments. States explicitly that the launchers are deprecated and that
  `PORCH_NO_TUI` should not be set.
- Verb retargeting:
  | Was | Now |
  | --- | --- |
  | `PORCH_NO_TUI=1 ./avm tf-test-unit` | `avm test unit` |
  | `PORCH_NO_TUI=1 ./avm tf-test-integration` | `avm test integration` |
  | `AVM_EXAMPLE=<name> ./avm test-examples` | `avm test e2e` |
  | `PORCH_NO_TUI=1 ./avm pre-commit` | `avm pre-commit` |
  | `PORCH_NO_TUI=1 ./avm pr-check` | `avm pr-check` |
- `avm test e2e` has **no per-example filter**, so the old `AVM_EXAMPLE`
  guidance is replaced with a note that it deploys, idempotency-checks and
  destroys every example, and that a `.e2eignore` marker excludes one.
- The dead `mapotf-configs/pre-commit` link is replaced: those configs now ship
  inside `Avm.Authoring` and are applied by `avm transform` (which
  `avm pre-commit` runs). A repository-committed `config/mapotf/pre-commit`
  still overrides them.
- Shell fences switched from `bash` to `pwsh`.

`.../references/terraform-test.md`

- Same verb retargeting in the comparison table and the *Running Tests* section.
- `setup.sh` -> `setup.ps1`. The PowerShell test runner **rejects** `.sh`
  hooks fail-fast, so the previously documented behaviour no longer exists.
- The `terraform test -no-cleanup` note now says *not via `avm test`* rather
  than *not via `./avm`*.

## Not included

- `managed-files/root` has **no** `.gitignore`, so the related F07 finding
  (the `.avm` ignore entry) has no governance-managed target. It is closed on
  the module side instead: `Avm.Authoring` no longer requires or creates
  `.avm/`, so the entry is now harmless.
- The new generic line-merge managed-file feature (`.avm-managed-lines.json`)
  is deliberately **not** added here yet. `Avm.Authoring` skips that file when
  syncing, but the current governance sync would copy it into every repository as
  a literal file. It should land once governance moves onto the module.

## Related

- `Azure/azure-verified-modules-tools` - `Avm.Authoring` 0.1.5, which fixes
  the launcher/tooling behaviour this skill now documents.