### PR TITLE
fix(tf-repo-mgmt): key terraform state per repository, not per module

### DIFF
--- a/.github/actions/avm-repos/scripts/Get-RepositoriesWhereAppInstalled.ps1
+++ b/.github/actions/avm-repos/scripts/Get-RepositoriesWhereAppInstalled.ps1
@@ -149,6 +149,23 @@ foreach ($installedRepository in $installedRepositories | Sort-Object -Property 
   }
 }
 
+# Two repositories can publish the same module during a provider migration, for
+# example terraform-azurerm-avm-res-x alongside terraform-azure-avm-res-x. They
+# no longer collide in Terraform state, which is keyed per repository, but they
+# do share a meta-data.csv entry and repository group configuration.
+$duplicateModules = $repos | Group-Object -Property { $_.repoId } | Where-Object { $_.Count -gt 1 }
+foreach ($duplicate in $duplicateModules)
+{
+  $duplicateRepoNames = ($duplicate.Group | ForEach-Object { $_.repoName } | Sort-Object) -join ", "
+  $issue = @{
+    repoId   = $duplicate.Name
+    message  = "Module '$($duplicate.Name)' is published from more than one repository: $duplicateRepoNames. They share a meta-data.csv entry and repository group configuration. Confirm this is intentional, such as a provider migration, or archive the redundant repository."
+    severity = "warning"
+  }
+  Write-Warning $issue.message
+  $issues += $issue
+}
+
 if (!$issues.Count -eq 0)
 {
   Write-Host "Issues found for"

--- a/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
+++ b/tf-repo-mgmt/scripts/Invoke-RepositorySync.ps1
@@ -218,6 +218,7 @@ $issueLog = Invoke-TerraformInit `
     -terraformModulePath $terraformModulePath `
     -repositoryCreationModeEnabled $repositoryCreationModeEnabled.IsPresent `
     -repoId $repoId `
+    -repoName $repoName `
     -orgAndRepoName $orgAndRepoName `
     -stateResourceGroupName $stateResourceGroupName `
     -stateStorageAccountName $stateStorageAccountName `
@@ -226,7 +227,7 @@ $issueLog = Invoke-TerraformInit `
 
 $issueLog = Invoke-TerraformPlanAndApply `
     -terraformModulePath $terraformModulePath `
-    -repoId $repoId `
+    -repoName $repoName `
     -orgAndRepoName $orgAndRepoName `
     -planOnly $planOnly `
     -resourceTypesThatCannotBeDestroyed $resourceTypesThatCannotBeDestroyed `

--- a/tf-repo-mgmt/scripts/lib/TerraformOperations.ps1
+++ b/tf-repo-mgmt/scripts/lib/TerraformOperations.ps1
@@ -24,6 +24,134 @@ function Clear-TerraformWorkspace {
     }
 }
 
+# Returns $true or $false for blob existence, or $null when the check itself
+# failed, so the caller can tell "not there" apart from "could not tell".
+function Test-TerraformStateBlob {
+    param(
+        [string]$storageAccountName,
+        [string]$containerName,
+        [string]$blobName
+    )
+
+    $output = az storage blob exists `
+        --account-name $storageAccountName `
+        --container-name $containerName `
+        --name $blobName `
+        --auth-mode login `
+        --query exists -o tsv 2>&1
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Could not check whether state blob '$blobName' exists. $($output | Out-String)"
+        return $null
+    }
+
+    return (($output | Out-String).Trim() -eq "true")
+}
+
+# Migrates a repository's state from the legacy module-scoped blob key to the
+# repository-scoped one. The legacy key dropped the provider segment from the
+# repository name, so every repository publishing the same module shared a single
+# state blob and rewrote the others' resources on each run. The copy is only made
+# when the legacy state actually describes this repository, so a repository that
+# never owned that state starts empty rather than adopting another's resources.
+function Copy-TerraformStateToRepositoryKey {
+    param(
+        [string]$legacyBlobName,
+        [string]$repositoryBlobName,
+        [string]$repoName,
+        [string]$storageAccountName,
+        [string]$containerName
+    )
+
+    if (!$storageAccountName -or !$containerName) {
+        Write-Warning "No state storage details were supplied, so the state key migration was skipped."
+        return $true
+    }
+
+    if ($legacyBlobName -eq $repositoryBlobName) {
+        return $true
+    }
+
+    $repositoryBlobExists = Test-TerraformStateBlob -storageAccountName $storageAccountName -containerName $containerName -blobName $repositoryBlobName
+    if ($null -eq $repositoryBlobExists) {
+        return $false
+    }
+
+    if ($repositoryBlobExists) {
+        return $true
+    }
+
+    $legacyBlobExists = Test-TerraformStateBlob -storageAccountName $storageAccountName -containerName $containerName -blobName $legacyBlobName
+    if ($null -eq $legacyBlobExists) {
+        return $false
+    }
+
+    if (!$legacyBlobExists) {
+        Write-Host "No existing state for '$repoName'. Starting from an empty state."
+        return $true
+    }
+
+    $legacyStateFile = Join-Path ([System.IO.Path]::GetTempPath()) "$([guid]::NewGuid()).tfstate"
+
+    try {
+        $downloadOutput = az storage blob download `
+            --account-name $storageAccountName `
+            --container-name $containerName `
+            --name $legacyBlobName `
+            --file $legacyStateFile `
+            --auth-mode login `
+            --no-progress 2>&1
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Could not download legacy state blob '$legacyBlobName'. $($downloadOutput | Out-String)"
+            return $false
+        }
+
+        $legacyState = Get-Content -Path $legacyStateFile -Raw | ConvertFrom-Json
+
+        $legacyRepository = $legacyState.resources |
+            Where-Object { $_.mode -eq "managed" -and $_.type -eq "github_repository" } |
+            Select-Object -First 1
+
+        $legacyRepositoryName = $null
+        if ($legacyRepository -and $legacyRepository.instances.Count -gt 0) {
+            $legacyRepositoryName = $legacyRepository.instances[0].attributes.name
+        }
+
+        if ($legacyRepositoryName -ne $repoName) {
+            Write-Warning "Legacy state blob '$legacyBlobName' describes '$legacyRepositoryName', not '$repoName'. Starting '$repoName' from an empty state so it does not adopt another repository's resources."
+            return $true
+        }
+
+        Write-Host "Migrating state for '$repoName' from '$legacyBlobName' to '$repositoryBlobName'."
+
+        $uploadOutput = az storage blob upload `
+            --account-name $storageAccountName `
+            --container-name $containerName `
+            --name $repositoryBlobName `
+            --file $legacyStateFile `
+            --auth-mode login `
+            --no-progress 2>&1
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Could not write state blob '$repositoryBlobName'. $($uploadOutput | Out-String)"
+            return $false
+        }
+
+        Write-Host "Migrated state for '$repoName' to '$repositoryBlobName'."
+        return $true
+    }
+    catch {
+        Write-Warning "State key migration for '$repoName' failed. $($_.Exception.Message)"
+        return $false
+    }
+    finally {
+        if (Test-Path $legacyStateFile) {
+            Remove-Item $legacyStateFile -Force
+        }
+    }
+}
+
 # Runs `terraform init`. In repository-creation mode this is a local-backend
 # bootstrap (writes `backend_override.tf` first); otherwise it points at the
 # remote AzureRM backend using the supplied state-storage parameters.
@@ -32,6 +160,7 @@ function Invoke-TerraformInit {
         [string]$terraformModulePath,
         [bool]$repositoryCreationModeEnabled,
         [string]$repoId,
+        [string]$repoName,
         [string]$orgAndRepoName,
         [string]$stateResourceGroupName,
         [string]$stateStorageAccountName,
@@ -56,6 +185,21 @@ terraform {
             -workingDirectory $terraformModulePath `
             -printOutput
     } else {
+        $stateBlobName = "$($repoName).tfstate"
+
+        $migrated = Copy-TerraformStateToRepositoryKey `
+            -legacyBlobName "$($repoId).tfstate" `
+            -repositoryBlobName $stateBlobName `
+            -repoName $repoName `
+            -storageAccountName $stateStorageAccountName `
+            -containerName $stateContainerName
+
+        if (!$migrated) {
+            Write-Warning "Terraform state key migration failed for $orgAndRepoName. Exiting."
+            $issueLog = Add-IssueToLog -orgAndRepoName $orgAndRepoName -type "state-migration-failed" -message "Terraform state key migration failed for $orgAndRepoName." -data $null -issueLog $issueLog
+            exit 1
+        }
+
         $result = Invoke-TerraformWithRetry `
             -commands @(
                 @{
@@ -64,7 +208,7 @@ terraform {
                         "-backend-config=`"resource_group_name=$stateResourceGroupName`"",
                         "-backend-config=`"storage_account_name=$stateStorageAccountName`"",
                         "-backend-config=`"container_name=$stateContainerName`"",
-                        "-backend-config=`"key=$($repoId).tfstate`""
+                        "-backend-config=`"key=$stateBlobName`""
                     )
                     OutputLog = "init.log"
                 }
@@ -72,7 +216,7 @@ terraform {
             -workingDirectory $terraformModulePath `
             -stateStorageAccountName $stateStorageAccountName `
             -stateContainerName $stateContainerName `
-            -stateBlobName "$($repoId).tfstate" `
+            -stateBlobName $stateBlobName `
             -printOutput
     }
 
@@ -91,7 +235,7 @@ terraform {
 function Invoke-TerraformPlanAndApply {
     param(
         [string]$terraformModulePath,
-        [string]$repoId,
+        [string]$repoName,
         [string]$orgAndRepoName,
         [bool]$planOnly,
         [string[]]$resourceTypesThatCannotBeDestroyed,
@@ -100,17 +244,20 @@ function Invoke-TerraformPlanAndApply {
         [array]$issueLog
     )
 
+    $stateBlobName = "$($repoName).tfstate"
+    $planFileName = "$($repoName).tfplan"
+
     $result = Invoke-TerraformWithRetry `
         -commands @(
             @{
-                Arguments = @("plan", "-out=`"$($repoId).tfplan`"")
+                Arguments = @("plan", "-out=`"$planFileName`"")
                 OutputLog = "plan.log"
             }
         ) `
         -workingDirectory $terraformModulePath `
         -stateStorageAccountName $stateStorageAccountName `
         -stateContainerName $stateContainerName `
-        -stateBlobName "$($repoId).tfstate" `
+        -stateBlobName $stateBlobName `
         -printOutput
 
     if (!$result.success) {
@@ -119,7 +266,7 @@ function Invoke-TerraformPlanAndApply {
         exit 1
     }
 
-    $plan = $(terraform -chdir="$terraformModulePath" show -json "$($repoId).tfplan") | ConvertFrom-Json
+    $plan = $(terraform -chdir="$terraformModulePath" show -json "$planFileName") | ConvertFrom-Json
 
     if (!$plan -or !$plan.resource_changes) {
         Write-Warning "Failed to parse Terraform plan for $orgAndRepoName. Exiting."
@@ -155,14 +302,14 @@ function Invoke-TerraformPlanAndApply {
         $result = Invoke-TerraformWithRetry `
             -commands @(
                 @{
-                    Arguments = @("apply", "$($repoId).tfplan")
+                    Arguments = @("apply", "$planFileName")
                     OutputLog = "apply.log"
                 }
             ) `
             -workingDirectory $terraformModulePath `
             -stateStorageAccountName $stateStorageAccountName `
             -stateContainerName $stateContainerName `
-            -stateBlobName "$($repoId).tfstate" `
+            -stateBlobName $stateBlobName `
             -printOutput `
             -maxRetries 0
 
@@ -171,18 +318,18 @@ function Invoke-TerraformPlanAndApply {
             $result = Invoke-TerraformWithRetry `
                 -commands @(
                     @{
-                        Arguments = @("plan", "-out=`"$($repoId).tfplan`"")
+                        Arguments = @("plan", "-out=`"$planFileName`"")
                         OutputLog = "plan.log"
                     },
                     @{
-                        Arguments = @("apply", "$($repoId).tfplan")
+                        Arguments = @("apply", "$planFileName")
                         OutputLog = "apply.log"
                     }
                 ) `
                 -workingDirectory $terraformModulePath `
                 -stateStorageAccountName $stateStorageAccountName `
                 -stateContainerName $stateContainerName `
-                -stateBlobName "$($repoId).tfstate" `
+                -stateBlobName $stateBlobName `
                 -printOutput
         }
 


### PR DESCRIPTION
## The real problem

The Terraform backend key was `<moduleId>.tfstate`, and `moduleId` is the repository name with the provider segment stripped ([`Get-RepositoriesWhereAppInstalled.ps1:85-86`](https://github.com/Azure/avm-terraform-governance/blob/main/.github/actions/avm-repos/scripts/Get-RepositoriesWhereAppInstalled.ps1#L85-L86)):

```powershell
$parts = $installedRepository.name.Split("-")            # terraform|azure|avm|res|network|expressrouteport
$moduleName = $parts[2..($parts.Length - 1)] -join "-"   # avm-res-network-expressrouteport
```

So two repositories publishing the same module share one state blob:

| module | repositories | status |
| --- | --- | --- |
| `avm-res-network-expressrouteport` | `terraform-azapi-*`, `terraform-azure-*` | both in the matrix, thrashing every 4 hours |
| `avm-res-insights-privatelinkscope` | `terraform-azurerm-*`, `terraform-azure-*` | app not yet installed on the `azure` repo |

`github_repository_name` is the **full** repository name while the state was keyed on the **stripped** name, so each run rewrote the other repository's resources:

```
Plan: 74 to add, 5 to change, 27 to destroy.

  ~ name = "Azure-terraform-azapi-avm-res-network-expressrouteport"
         -> "Azure-terraform-azure-avm-res-network-expressrouteport" # forces replacement
```

The managed identity, its three federated credentials, the AAD group membership, all Actions/Dependabot secrets, every environment and every issue label were destroyed and recreated on every run. `resourceTypesThatCannotBeDestroyed` only guards `github_repository`, so nothing blocked it.

The state-lock failures chased in #528, #532 and #535 were a **symptom**: both jobs start in the same matrix second and fight over the same blob lease. Those PRs made the recovery work, which is why the error shape changed from `Error acquiring the state lock` to `Error releasing the state lock` / `412 the lease for the blob has expired` — the two jobs were breaking each other's *live* leases. The `concurrency` block added in #535 doesn't help either, because it serialises *runs*, not matrix *jobs within* a run.

This grows with the `azurerm` → `azure` provider migration: 25 `azure` repos exist today, 194 `azurerm` repos still to migrate.

## The fix

**Key the state on the repository, not the module.** `$repoName` is already available in `Invoke-RepositorySync.ps1`.

- Backend key becomes `<repoName>.tfstate`, plan file becomes `<repoName>.tfplan`.
- New `Copy-TerraformStateToRepositoryKey`, called from `Invoke-TerraformInit` before init. It is self-healing and effectively runs once per repository:
  - target key exists → already migrated, no-op (one `az` call on every subsequent run)
  - legacy key absent → new repository, start fresh
  - legacy key present → download it, read the `github_repository` resource's `name` attribute, and copy **only if it names this repository**

  A repository therefore never inherits another's state; the one that never owned the legacy blob starts empty. Since the thrash had already destroyed that side's resources, and every Azure/GitHub resource is named per-repository (`Azure-terraform-azapi-…` vs `Azure-terraform-azure-…`), there is nothing for it to collide with.
- Migration failure is **fatal**, so a transient `az` error can't silently drop a repository to an empty state and try to recreate live resources.
- The legacy blob is left in place as a rollback safety net.
- `Get-RepositoriesWhereAppInstalled.ps1` now raises a `warning` issue when two repositories share a `repoId`. Not fatal — it's legitimate during a provider migration — but they also share a `meta-data.csv` entry and repository-group config, so it needs surfacing.

## Testing

A harness (compiled `az.exe`/`terraform.exe` stubs over a fake blob store, driven through the same `pwsh -command ". <step>"` → called script → dot-sourced lib chain the workflow uses) covers 12 cases:

| case | expected |
| --- | --- |
| legacy state owned by this repo | copied to the repository key |
| legacy state owned by the *other* repo | not adopted, starts empty |
| both colliding repos | independent state |
| already migrated | no-op, legacy blob never re-read |
| brand new repo, no legacy state | starts fresh, nothing copied |
| legacy state with no `github_repository` | not adopted |
| exists / download / upload failure | fatal (`$false`) |
| no storage details | skipped, `az` never called |
| temp file | cleaned up |
| `Invoke-TerraformInit` end to end | migrates, then inits against `<repoName>.tfstate` |

All 12 pass against this branch and **all 12 fail against `main`** — including the end-to-end case, which shows `main` initialising against the shared `key=avm-res-network-expressrouteport.tfstate`.

The existing 9-case lock-recovery harness from #535 still passes, so there's no regression there.

## Follow-up

Worth deciding separately whether `avm-res-network-expressrouteport` should keep both an `azapi` and an `azure` repository long-term, or whether one should be archived. This change makes coexistence safe either way.
