### PR TITLE
Add avm-res-avs-privatecloud to canary group

### DIFF
--- a/tf-repo-mgmt/repository-config/config.json
+++ b/tf-repo-mgmt/repository-config/config.json
@@ -30,7 +30,8 @@
         "avm-res-documentdb-mongocluster",
         "avm-res-compute-disk",
         "avm-res-dbformysql-flexibleserver",
-        "avm-res-cdn-profile"
+        "avm-res-cdn-profile",
+        "avm-res-avs-privatecloud"
       ],
       "topics": [
         "canary"


### PR DESCRIPTION
Adds `avm-res-avs-privatecloud` ([terraform-azurerm-avm-res-avs-privatecloud](https://github.com/Azure/terraform-azurerm-avm-res-avs-privatecloud)) to the `canary` repository group in `tf-repo-mgmt/repository-config/config.json`.