### PR TITLE
Fix Docker/Podman socket mounting in avm scripts (#541)

### DIFF
--- a/managed-files/root/avm
+++ b/managed-files/root/avm
@@ -57,9 +57,16 @@ if [ -n "${AVM_TMP_DIR}" ]; then
   TMP_MOUNT="-v ${AVM_TMP_DIR}:/tmp"
 fi
 
-# If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
-if [ -S /var/run/docker.sock ]; then
-  DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
+# Mount the container engine socket so examples using the docker provider can reach it.
+# AVM_DOCKER_SOCKET overrides; otherwise default to the standard docker socket path.
+if [ -n "${AVM_DOCKER_SOCKET}" ]; then
+  DOCKER_SOCKET_PATH="${AVM_DOCKER_SOCKET}"
+elif [ "${CONTAINER_RUNTIME}" = "docker" ]; then
+  DOCKER_SOCKET_PATH="/var/run/docker.sock"
+fi
+
+if [ -n "${DOCKER_SOCKET_PATH}" ] && [ -S "${DOCKER_SOCKET_PATH}" ]; then
+  DOCKER_SOCK_MOUNT="-v ${DOCKER_SOCKET_PATH}:/var/run/docker.sock"
 fi
 
 # SSL certificate handling:

--- a/managed-files/root/avm.ps1
+++ b/managed-files/root/avm.ps1
@@ -78,6 +78,27 @@ if ($env:PORCH_BASE_URL) {
   $PORCH_BASE_URL_MAKE_ADD = "PORCH_BASE_URL=$($env:PORCH_BASE_URL)"
 }
 
+# Mount the container engine socket so examples using the docker provider can reach it.
+# AVM_DOCKER_SOCKET overrides; otherwise default to the standard docker socket path.
+$DOCKER_SOCKET_PATH = $null
+if ($env:AVM_DOCKER_SOCKET) {
+  $DOCKER_SOCKET_PATH = $env:AVM_DOCKER_SOCKET
+}
+elseif ($CONTAINER_RUNTIME -eq "docker" -and -not $IsWindows) {
+  $DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+}
+
+$DOCKER_SOCK_MOUNT = $null
+if ($DOCKER_SOCKET_PATH) {
+  if ($IsWindows) {
+    # Windows: path is inside the runtime's VM, existence can't be checked here.
+    $DOCKER_SOCK_MOUNT = @("-v", "${DOCKER_SOCKET_PATH}:/var/run/docker.sock")
+  }
+  elseif (Test-Path $DOCKER_SOCKET_PATH) {
+    $DOCKER_SOCK_MOUNT = @("-v", "${DOCKER_SOCKET_PATH}:/var/run/docker.sock")
+  }
+}
+
 # Check if we are running in a container
 # If we are then just run make directly
 if (-not $env:AVM_IN_CONTAINER) {
@@ -110,6 +131,10 @@ if (-not $env:AVM_IN_CONTAINER) {
 
   if ($AZURE_CONFIG_MOUNT -and $AZURE_CONFIG_MOUNT_PATH) {
     $dockerArgs += @($AZURE_CONFIG_MOUNT, $AZURE_CONFIG_MOUNT_PATH)
+  }
+
+  if ($DOCKER_SOCK_MOUNT) {
+    $dockerArgs += $DOCKER_SOCK_MOUNT
   }
 
   # Add environment variables

--- a/tests/terraform-azure-avm-res-mock/avm
+++ b/tests/terraform-azure-avm-res-mock/avm
@@ -57,9 +57,16 @@ if [ -n "${AVM_TMP_DIR}" ]; then
   TMP_MOUNT="-v ${AVM_TMP_DIR}:/tmp"
 fi
 
-# If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
-if [ -S /var/run/docker.sock ]; then
-  DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
+# Mount the container engine socket so examples using the docker provider can reach it.
+# AVM_DOCKER_SOCKET overrides; otherwise default to the standard docker socket path.
+if [ -n "${AVM_DOCKER_SOCKET}" ]; then
+  DOCKER_SOCKET_PATH="${AVM_DOCKER_SOCKET}"
+elif [ "${CONTAINER_RUNTIME}" = "docker" ]; then
+  DOCKER_SOCKET_PATH="/var/run/docker.sock"
+fi
+
+if [ -n "${DOCKER_SOCKET_PATH}" ] && [ -S "${DOCKER_SOCKET_PATH}" ]; then
+  DOCKER_SOCK_MOUNT="-v ${DOCKER_SOCKET_PATH}:/var/run/docker.sock"
 fi
 
 # SSL certificate handling:

--- a/tests/terraform-azure-avm-res-mock/avm.ps1
+++ b/tests/terraform-azure-avm-res-mock/avm.ps1
@@ -78,6 +78,27 @@ if ($env:PORCH_BASE_URL) {
   $PORCH_BASE_URL_MAKE_ADD = "PORCH_BASE_URL=$($env:PORCH_BASE_URL)"
 }
 
+# Mount the container engine socket so examples using the docker provider can reach it.
+# AVM_DOCKER_SOCKET overrides; otherwise default to the standard docker socket path.
+$DOCKER_SOCKET_PATH = $null
+if ($env:AVM_DOCKER_SOCKET) {
+  $DOCKER_SOCKET_PATH = $env:AVM_DOCKER_SOCKET
+}
+elseif ($CONTAINER_RUNTIME -eq "docker" -and -not $IsWindows) {
+  $DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+}
+
+$DOCKER_SOCK_MOUNT = $null
+if ($DOCKER_SOCKET_PATH) {
+  if ($IsWindows) {
+    # Windows: path is inside the runtime's VM, existence can't be checked here.
+    $DOCKER_SOCK_MOUNT = @("-v", "${DOCKER_SOCKET_PATH}:/var/run/docker.sock")
+  }
+  elseif (Test-Path $DOCKER_SOCKET_PATH) {
+    $DOCKER_SOCK_MOUNT = @("-v", "${DOCKER_SOCKET_PATH}:/var/run/docker.sock")
+  }
+}
+
 # Check if we are running in a container
 # If we are then just run make directly
 if (-not $env:AVM_IN_CONTAINER) {
@@ -110,6 +131,10 @@ if (-not $env:AVM_IN_CONTAINER) {
 
   if ($AZURE_CONFIG_MOUNT -and $AZURE_CONFIG_MOUNT_PATH) {
     $dockerArgs += @($AZURE_CONFIG_MOUNT, $AZURE_CONFIG_MOUNT_PATH)
+  }
+
+  if ($DOCKER_SOCK_MOUNT) {
+    $dockerArgs += $DOCKER_SOCK_MOUNT
   }
 
   # Add environment variables

--- a/tests/terraform-azurerm-avm-res-mock/avm
+++ b/tests/terraform-azurerm-avm-res-mock/avm
@@ -57,9 +57,16 @@ if [ -n "${AVM_TMP_DIR}" ]; then
   TMP_MOUNT="-v ${AVM_TMP_DIR}:/tmp"
 fi
 
-# If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
-if [ -S /var/run/docker.sock ]; then
-  DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
+# Mount the container engine socket so examples using the docker provider can reach it.
+# AVM_DOCKER_SOCKET overrides; otherwise default to the standard docker socket path.
+if [ -n "${AVM_DOCKER_SOCKET}" ]; then
+  DOCKER_SOCKET_PATH="${AVM_DOCKER_SOCKET}"
+elif [ "${CONTAINER_RUNTIME}" = "docker" ]; then
+  DOCKER_SOCKET_PATH="/var/run/docker.sock"
+fi
+
+if [ -n "${DOCKER_SOCKET_PATH}" ] && [ -S "${DOCKER_SOCKET_PATH}" ]; then
+  DOCKER_SOCK_MOUNT="-v ${DOCKER_SOCKET_PATH}:/var/run/docker.sock"
 fi
 
 # SSL certificate handling:

--- a/tests/terraform-azurerm-avm-res-mock/avm.ps1
+++ b/tests/terraform-azurerm-avm-res-mock/avm.ps1
@@ -78,6 +78,27 @@ if ($env:PORCH_BASE_URL) {
   $PORCH_BASE_URL_MAKE_ADD = "PORCH_BASE_URL=$($env:PORCH_BASE_URL)"
 }
 
+# Mount the container engine socket so examples using the docker provider can reach it.
+# AVM_DOCKER_SOCKET overrides; otherwise default to the standard docker socket path.
+$DOCKER_SOCKET_PATH = $null
+if ($env:AVM_DOCKER_SOCKET) {
+  $DOCKER_SOCKET_PATH = $env:AVM_DOCKER_SOCKET
+}
+elseif ($CONTAINER_RUNTIME -eq "docker" -and -not $IsWindows) {
+  $DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+}
+
+$DOCKER_SOCK_MOUNT = $null
+if ($DOCKER_SOCKET_PATH) {
+  if ($IsWindows) {
+    # Windows: path is inside the runtime's VM, existence can't be checked here.
+    $DOCKER_SOCK_MOUNT = @("-v", "${DOCKER_SOCKET_PATH}:/var/run/docker.sock")
+  }
+  elseif (Test-Path $DOCKER_SOCKET_PATH) {
+    $DOCKER_SOCK_MOUNT = @("-v", "${DOCKER_SOCKET_PATH}:/var/run/docker.sock")
+  }
+}
+
 # Check if we are running in a container
 # If we are then just run make directly
 if (-not $env:AVM_IN_CONTAINER) {
@@ -110,6 +131,10 @@ if (-not $env:AVM_IN_CONTAINER) {
 
   if ($AZURE_CONFIG_MOUNT -and $AZURE_CONFIG_MOUNT_PATH) {
     $dockerArgs += @($AZURE_CONFIG_MOUNT, $AZURE_CONFIG_MOUNT_PATH)
+  }
+
+  if ($DOCKER_SOCK_MOUNT) {
+    $dockerArgs += $DOCKER_SOCK_MOUNT
   }
 
   # Add environment variables


### PR DESCRIPTION
## Problem
Module examples using the `kreuzwerker/docker` provider need access to the host container engine's socket during `terraform plan`/`apply`. The bash `avm` script only auto-mounted the default Docker socket path (`/var/run/docker.sock`), so the mount was silently skipped when running with Podman, whose socket lives elsewhere (e.g. rootless Podman uses `$XDG_RUNTIME_DIR/podman/podman.sock`, Podman Desktop on Windows exposes its own path). The PowerShell `avm.ps1` script (used notably on Windows with Podman Desktop) didn't mount any socket at all.

This caused `terraform plan` to fail with:
```
Error: Error pinging Docker server, please make sure that unix:///var/run/docker.sock is reachable...
```

## Fix
Both `managed-files/root/avm` (bash) and `managed-files/root/avm.ps1` (PowerShell) now:
- Support an `AVM_DOCKER_SOCKET` env var so users can explicitly point at any socket path (Docker or Podman).
- Keep the existing `/var/run/docker.sock` default behavior when `CONTAINER_RUNTIME=docker` (no change for existing Docker users).
- Mount the resolved path to `/var/run/docker.sock` inside the container so no provider configuration changes are needed downstream.

Podman users set `AVM_DOCKER_SOCKET` explicitly

Synced the identical change into the `avm`/`avm.ps1` test fixture copies under `tests/terraform-azurerm-avm-res-mock` and `tests/terraform-azure-avm-res-mock`, which were verified to be byte-identical to `managed-files/root` before this change. `managed-files/canary/avm.ps1` (an unrelated deprecated-launcher stub) was left untouched.

## Testing
- Verified `avm.ps1` parses cleanly via `[System.Management.Automation.Language.Parser]::ParseFile`.
- Verified `avm` passes `bash -n`.
- **Manually tested on real environments**: confirmed `AVM_DOCKER_SOCKET` correctly mounts the socket and a full `terraform apply`/`destroy` succeeds against the `acr` example (uses `kreuzwerker/docker` provider) on both native Windows with Podman Desktop and WSL Ubuntu.

Fixes #541