### PR TITLE
fix: avoid null repository sync issues

### DIFF
--- a/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
@@ -27,7 +27,7 @@ function Invoke-AvmPreCommitForRepository {
         Push-Location $tempDir
         try {
             Import-Module Avm.Authoring -Force
-            Invoke-AvmPreCommit `
+            $null = Invoke-AvmPreCommit `
                 -Ecosystem terraform `
                 -RepoId $repoId `
                 -ManagedFilesLocalPath $managedFilesBaseDir `


### PR DESCRIPTION
## Summary

- suppress structured output emitted by `Invoke-AvmPreCommit` inside the repository sync helper
- preserve exception propagation while ensuring the helper emits only its result object
- prevent command results from being captured alongside the helper result and projected as null `IssueLog` entries

## Context

Follow-up to [#543](https://github.com/Azure/avm-terraform-governance/pull/543) after [run 31255361475](https://github.com/Azure/avm-terraform-governance/actions/runs/31255361475/job/93097856807) wrote `[null, null]` to the issue log despite no real issue.