### PR TITLE
fix: include pre-commit issue diagnostics

### DIFF
--- a/tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1
@@ -39,6 +39,41 @@ Assert-Throws -MessagePattern "avm pre-commit returned status 'fail'.*transform:
     })
 }
 
+Assert-Throws -MessagePattern "avm pre-commit returned status 'fail'.*check convention: fail - Required file 'README.md' does not exist.*'.gitignore' is missing required glob '.terraform'.*docs: fail - 'README.md' is out of date.*" -Action {
+    Assert-AvmPreCommitResult -preCommitResult ([pscustomobject]@{
+        Status = "fail"
+        Steps = @(
+            [pscustomobject]@{
+                Step = "check convention"
+                Status = "fail"
+                Error = $null
+                Result = [pscustomobject]@{
+                    Issues = @(
+                        [pscustomobject]@{
+                            Message = "Required file 'README.md' does not exist."
+                        }
+                        [pscustomobject]@{
+                            Message = "'.gitignore' is missing required glob '.terraform'."
+                        }
+                    )
+                }
+            }
+            [pscustomobject]@{
+                Step = "docs"
+                Status = "fail"
+                Error = $null
+                Result = [pscustomobject]@{
+                    Issues = @(
+                        [pscustomobject]@{
+                            Message = "'README.md' is out of date."
+                        }
+                    )
+                }
+            }
+        )
+    })
+}
+
 Assert-Throws -MessagePattern "avm pre-commit returned status 'missing'.*" -Action {
     Assert-AvmPreCommitResult -preCommitResult $null
 }

--- a/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
@@ -19,10 +19,40 @@ function Assert-AvmPreCommitResult {
             $preCommitResult.Steps |
                 Where-Object { $_.Status -in @("fail", "error") } |
                 ForEach-Object {
-                    if ([string]::IsNullOrWhiteSpace($_.Error)) {
-                        "$($_.Step): $($_.Status)"
+                    $details = @(
+                        $errorProperty = $_.PSObject.Properties["Error"]
+                        if ($null -ne $errorProperty -and -not [string]::IsNullOrWhiteSpace([string]$errorProperty.Value)) {
+                            [string]$errorProperty.Value
+                        }
+
+                        $resultProperty = $_.PSObject.Properties["Result"]
+                        if ($null -ne $resultProperty -and $null -ne $resultProperty.Value) {
+                            $issuesProperty = $resultProperty.Value.PSObject.Properties["Issues"]
+                            if ($null -ne $issuesProperty) {
+                                foreach ($issue in @($issuesProperty.Value)) {
+                                    if ($null -eq $issue) {
+                                        continue
+                                    }
+
+                                    $messageProperty = $issue.PSObject.Properties["Message"]
+                                    $message = if ($null -ne $messageProperty) {
+                                        [string]$messageProperty.Value
+                                    } else {
+                                        [string]$issue
+                                    }
+                                    if (-not [string]::IsNullOrWhiteSpace($message)) {
+                                        $message
+                                    }
+                                }
+                            }
+                        }
+                    )
+
+                    $stepSummary = "$($_.Step): $($_.Status)"
+                    if ($details.Count -eq 0) {
+                        $stepSummary
                     } else {
-                        "$($_.Step): $($_.Status) - $($_.Error)"
+                        "$stepSummary - $($details -join ' | ')"
                     }
                 }
         }


### PR DESCRIPTION
## Summary
- include nested `Step.Result.Issues` messages in failed AVM pre-commit step diagnostics
- preserve existing failed-step output when no nested issues are returned
- cover multiple failed steps and multiple issue messages with a regression test

## Validation
- `pwsh -NoLogo -NoProfile -File .\tf-repo-mgmt\scripts\Test-AvmPreCommit.ps1`
- `pwsh -NoLogo -NoProfile -Command "& .\tf-repo-mgmt\scripts\Test-RepositoryConfig.ps1; & .\tf-repo-mgmt\scripts\Test-AvmPreCommit.ps1"`