### PR TITLE
fix: surface pre-commit convention diagnostics

### DIFF
--- a/tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1
@@ -6,14 +6,23 @@ $ErrorActionPreference = "Stop"
 function Assert-Throws {
     param(
         [scriptblock]$Action,
-        [string]$MessagePattern
+        [string]$MessagePattern,
+        [string]$ExpectedMessage,
+        [string]$MessageNotPattern
     )
 
     try {
         & $Action
     } catch {
-        if ($_.Exception.Message -notlike $MessagePattern) {
-            throw "Expected error matching '$MessagePattern', got '$($_.Exception.Message)'."
+        $message = $_.Exception.Message
+        if ($ExpectedMessage -and $message -cne $ExpectedMessage) {
+            throw "Expected error '$ExpectedMessage', got '$message'."
+        }
+        if ($MessagePattern -and $message -notlike $MessagePattern) {
+            throw "Expected error matching '$MessagePattern', got '$message'."
+        }
+        if ($MessageNotPattern -and $message -like $MessageNotPattern) {
+            throw "Expected error not matching '$MessageNotPattern', got '$message'."
         }
         return
     }
@@ -26,7 +35,10 @@ Assert-AvmPreCommitResult -preCommitResult ([pscustomobject]@{
     Steps = @()
 })
 
-Assert-Throws -MessagePattern "avm pre-commit returned status 'fail'.*transform: fail*" -Action {
+Assert-Throws `
+    -ExpectedMessage "avm pre-commit returned status 'fail'. Failed steps: transform: fail - Mapotf failed.." `
+    -MessageNotPattern "*Issues:*" `
+    -Action {
     Assert-AvmPreCommitResult -preCommitResult ([pscustomobject]@{
         Status = "fail"
         Steps = @(
@@ -34,6 +46,31 @@ Assert-Throws -MessagePattern "avm pre-commit returned status 'fail'.*transform:
                 Step = "transform"
                 Status = "fail"
                 Error = "Mapotf failed."
+            }
+        )
+    })
+}
+
+Assert-Throws `
+    -MessagePattern "avm pre-commit returned status 'fail'.*check convention: fail - Issues: Required file '_header.md' does not exist. | Required directory 'tests' must contain at least 1 immediate child item; found 0.*" `
+    -Action {
+    Assert-AvmPreCommitResult -preCommitResult ([pscustomobject]@{
+        Status = "fail"
+        Steps = @(
+            [pscustomobject]@{
+                Step = "check convention"
+                Status = "fail"
+                Error = $null
+                Result = [pscustomobject]@{
+                    Issues = @(
+                        [pscustomobject]@{
+                            Message = "Required file '_header.md' does not exist."
+                        }
+                        [pscustomobject]@{
+                            Message = "Required directory 'tests' must contain at least 1 immediate child item; found 0."
+                        }
+                    )
+                }
             }
         )
     })

--- a/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
@@ -19,10 +19,36 @@ function Assert-AvmPreCommitResult {
             $preCommitResult.Steps |
                 Where-Object { $_.Status -in @("fail", "error") } |
                 ForEach-Object {
-                    if ([string]::IsNullOrWhiteSpace($_.Error)) {
-                        "$($_.Step): $($_.Status)"
+                    $step = $_
+                    $stepSummary = if ([string]::IsNullOrWhiteSpace($step.Error)) {
+                        "$($step.Step): $($step.Status)"
                     } else {
-                        "$($_.Step): $($_.Status) - $($_.Error)"
+                        "$($step.Step): $($step.Status) - $($step.Error)"
+                    }
+
+                    $issueMessages = @(
+                        if (
+                            $step.PSObject.Properties.Name -contains "Result" -and
+                            $step.Result -and
+                            $step.Result.PSObject.Properties.Name -contains "Issues"
+                        ) {
+                            @($step.Result.Issues) |
+                                ForEach-Object {
+                                    $issue = $_
+                                    if ($issue -is [string]) {
+                                        $issue
+                                    } elseif ($issue -and $issue.PSObject.Properties.Name -contains "Message") {
+                                        [string]$issue.Message
+                                    }
+                                } |
+                                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+                        }
+                    )
+
+                    if ($issueMessages.Count -gt 0) {
+                        "$stepSummary - Issues: $($issueMessages -join ' | ')"
+                    } else {
+                        $stepSummary
                     }
                 }
         }


### PR DESCRIPTION
## Summary

- include every nonblank nested `Steps[].Result.Issues[].Message` in failed `Avm.Authoring` pre-commit step summaries
- preserve the existing error text exactly for failed steps that do not expose nested issues
- add focused regression coverage for ordered convention diagnostics and legacy failure rendering

## Context

This completes the governance-side diagnostics needed by https://github.com/Azure/azure-verified-modules-tools/pull/37. Repository Sync failures will now show the actual convention violations instead of only `check convention: fail`.

## Validation

- `tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1`
- PowerShell parser validation for both changed scripts
- independent code review with no remaining findings