### PR TITLE
feat(managed-files): broadcast footer templates

### DIFF
--- a/managed-files/README.md
+++ b/managed-files/README.md
@@ -2,4 +2,4 @@
 
 This directory is used to keep core files updated.
 
-Within `root/modules` and `root/examples`, `_all` is reserved for template subtrees synchronized into every existing immediate child directory. The `_all` directory itself is not copied to target repositories.
+Within any named parent directory under `root`, `<parent>/_all/<suffix>` is synchronized as `<parent>/<child>/<suffix>` for every existing immediate child directory. The `_all` directory itself is not copied, while `root/_all` remains a literal path.

--- a/managed-files/README.md
+++ b/managed-files/README.md
@@ -1,3 +1,5 @@
 # Managed Files
 
 This directory is used to keep core files updated.
+
+Within `root/modules` and `root/examples`, `_all` is reserved for template subtrees synchronized into every existing immediate child directory. The `_all` directory itself is not copied to target repositories.

--- a/managed-files/root/examples/_all/_footer.md
+++ b/managed-files/root/examples/_all/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/managed-files/root/modules/_all/_footer.md
+++ b/managed-files/root/modules/_all/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.


### PR DESCRIPTION
## Summary

- add reserved `modules/_all` and `examples/_all` footer templates
- keep both templates byte-identical to the root `_footer.md`
- document generic `<parent>/_all/<suffix>` broadcasting to every existing immediate child directory
- clarify that root-level `managed-files/root/_all/` remains literal

## Dependency

This change depends on tooling [PR #43](https://github.com/Azure/azure-verified-modules-tools/pull/43) and must remain in draft until an Avm.Authoring release containing generic nested `_all` managed-file broadcast support is available. Without that engine support, nested `_all` directories could be synchronized literally instead of expanded to each existing immediate child directory.

## Rollout order

1. Merge tooling [PR #43](https://github.com/Azure/azure-verified-modules-tools/pull/43).
2. Publish an Avm.Authoring release containing that change.
3. Confirm governance repository sync uses the released version.
4. Mark this change ready and merge it.
5. Run repository sync so existing module and example child directories receive `_footer.md`.

## Validation

- confirmed both new footer templates have the same SHA-256 hash as `managed-files/root/_footer.md`
- `git diff --check`

## Incident

- https://github.com/Azure/avm-terraform-governance/actions/runs/31389965076/job/93459190110