### PR TITLE
fix: upgrade Avm.Authoring during repository sync

### DIFF
--- a/tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1
@@ -30,6 +30,18 @@ function Assert-Throws {
     throw "Expected an error matching '$MessagePattern'."
 }
 
+function Assert-Equal {
+    param(
+        [object]$Actual,
+        [object]$Expected,
+        [string]$Description
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "Expected $Description to be '$Expected', got '$Actual'."
+    }
+}
+
 Assert-AvmPreCommitResult -preCommitResult ([pscustomobject]@{
     Status = "pass"
     Steps = @()
@@ -78,6 +90,112 @@ Assert-Throws `
 
 Assert-Throws -MessagePattern "avm pre-commit returned status 'missing'.*" -Action {
     Assert-AvmPreCommitResult -preCommitResult $null
+}
+
+$script:moduleImportCount = 0
+$script:moduleUpdateCount = 0
+$script:preCommitInvocationCount = 0
+$script:preCommitErrorCodes = @()
+$script:moduleUpdateParameters = @{}
+
+function Import-Module {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [string]$Name,
+        [switch]$Force
+    )
+
+    $script:moduleImportCount++
+}
+
+function Update-PSResource {
+    [CmdletBinding()]
+    param(
+        [string]$Name,
+        [string]$Scope,
+        [switch]$TrustRepository
+    )
+
+    $script:moduleUpdateCount++
+    $script:moduleUpdateParameters = @{} + $PSBoundParameters
+}
+
+function Invoke-AvmPreCommit {
+    param(
+        [string]$Ecosystem,
+        [string]$RepoId,
+        [string]$ManagedFilesLocalPath,
+        [string]$ConfigLocalPath
+    )
+
+    $script:preCommitInvocationCount++
+    if ($script:preCommitInvocationCount -le $script:preCommitErrorCodes.Count) {
+        $exception = [System.InvalidOperationException]::new("A newer version of Avm.Authoring is required.")
+        $exception | Add-Member -NotePropertyName Code -NotePropertyValue $script:preCommitErrorCodes[$script:preCommitInvocationCount - 1]
+        throw $exception
+    }
+
+    return [pscustomobject]@{
+        Status = "pass"
+        Steps = @()
+    }
+}
+
+try {
+    $script:preCommitErrorCodes = @("AVM1050")
+    $result = Invoke-AvmPreCommitWithUpgradeRetry `
+        -repoId "avm-res-test" `
+        -managedFilesBaseDir "managed-files" `
+        -repositoryConfigDir "repository-config"
+
+    Assert-Equal -Actual $result.Status -Expected "pass" -Description "pre-commit status after upgrade"
+    Assert-Equal -Actual $script:preCommitInvocationCount -Expected 2 -Description "pre-commit invocation count"
+    Assert-Equal -Actual $script:moduleImportCount -Expected 2 -Description "module import count"
+    Assert-Equal -Actual $script:moduleUpdateCount -Expected 1 -Description "module update count"
+    Assert-Equal -Actual $script:moduleUpdateParameters.Name -Expected "Avm.Authoring" -Description "updated module name"
+    Assert-Equal -Actual $script:moduleUpdateParameters.Scope -Expected "CurrentUser" -Description "module update scope"
+    Assert-Equal -Actual $script:moduleUpdateParameters.TrustRepository.IsPresent -Expected $true -Description "trusted repository switch"
+
+    $script:moduleImportCount = 0
+    $script:moduleUpdateCount = 0
+    $script:preCommitInvocationCount = 0
+    $script:preCommitErrorCodes = @("AVM9999")
+
+    Assert-Throws `
+        -ExpectedMessage "A newer version of Avm.Authoring is required." `
+        -Action {
+        Invoke-AvmPreCommitWithUpgradeRetry `
+            -repoId "avm-res-test" `
+            -managedFilesBaseDir "managed-files" `
+            -repositoryConfigDir "repository-config"
+    }
+
+    Assert-Equal -Actual $script:preCommitInvocationCount -Expected 1 -Description "unrelated error invocation count"
+    Assert-Equal -Actual $script:moduleImportCount -Expected 1 -Description "unrelated error import count"
+    Assert-Equal -Actual $script:moduleUpdateCount -Expected 0 -Description "unrelated error update count"
+
+    $script:moduleImportCount = 0
+    $script:moduleUpdateCount = 0
+    $script:preCommitInvocationCount = 0
+    $script:preCommitErrorCodes = @("AVM1050", "AVM1050")
+
+    Assert-Throws `
+        -ExpectedMessage "A newer version of Avm.Authoring is required." `
+        -Action {
+        Invoke-AvmPreCommitWithUpgradeRetry `
+            -repoId "avm-res-test" `
+            -managedFilesBaseDir "managed-files" `
+            -repositoryConfigDir "repository-config"
+    }
+
+    Assert-Equal -Actual $script:preCommitInvocationCount -Expected 2 -Description "retry failure invocation count"
+    Assert-Equal -Actual $script:moduleImportCount -Expected 2 -Description "retry failure import count"
+    Assert-Equal -Actual $script:moduleUpdateCount -Expected 1 -Description "retry failure update count"
+} finally {
+    Remove-Item Function:Import-Module
+    Remove-Item Function:Update-PSResource
+    Remove-Item Function:Invoke-AvmPreCommit
 }
 
 Write-Host "Avm pre-commit result tests passed."

--- a/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
+++ b/tf-repo-mgmt/scripts/lib/AvmPreCommit.ps1
@@ -62,6 +62,40 @@ function Assert-AvmPreCommitResult {
     throw "avm pre-commit returned status '$status'.$detail"
 }
 
+function Invoke-AvmPreCommitWithUpgradeRetry {
+    param(
+        [string]$repoId,
+        [string]$managedFilesBaseDir,
+        [string]$repositoryConfigDir
+    )
+
+    $preCommitParameters = @{
+        Ecosystem             = "terraform"
+        RepoId                = $repoId
+        ManagedFilesLocalPath = $managedFilesBaseDir
+        ConfigLocalPath       = $repositoryConfigDir
+    }
+
+    Import-Module Avm.Authoring -Force -ErrorAction Stop
+    try {
+        return Invoke-AvmPreCommit @preCommitParameters
+    } catch {
+        $exception = $_.Exception
+        $isModuleUpgradeRequired = (
+            $exception.PSObject.Properties.Name -contains "Code" -and
+            [string]$exception.Code -eq "AVM1050"
+        )
+        if (-not $isModuleUpgradeRequired) {
+            throw
+        }
+
+        Write-Host "A newer Avm.Authoring release became available. Upgrading the module and retrying avm pre-commit once." -ForegroundColor Yellow
+        Update-PSResource -Name Avm.Authoring -Scope CurrentUser -TrustRepository -ErrorAction Stop | Out-Null
+        Import-Module Avm.Authoring -Force -ErrorAction Stop
+        return Invoke-AvmPreCommit @preCommitParameters
+    }
+}
+
 function Invoke-AvmPreCommitForRepository {
     param(
         [string]$orgAndRepoName,
@@ -90,12 +124,10 @@ function Invoke-AvmPreCommitForRepository {
 
         Push-Location $tempDir
         try {
-            Import-Module Avm.Authoring -Force
-            $preCommitResult = Invoke-AvmPreCommit `
-                -Ecosystem terraform `
-                -RepoId $repoId `
-                -ManagedFilesLocalPath $managedFilesBaseDir `
-                -ConfigLocalPath $repositoryConfigDir
+            $preCommitResult = Invoke-AvmPreCommitWithUpgradeRetry `
+                -repoId $repoId `
+                -managedFilesBaseDir $managedFilesBaseDir `
+                -repositoryConfigDir $repositoryConfigDir
             Assert-AvmPreCommitResult -preCommitResult $preCommitResult
 
             $status = git status --porcelain


### PR DESCRIPTION
## Summary

- detect the `AVM1050` stale-module error when an `Avm.Authoring` release appears mid-run
- update and reload `Avm.Authoring`, then retry pre-commit exactly once
- preserve normal failure behavior for unrelated errors and repeated failures

## Context

[Repository Sync run 31402837924](https://github.com/Azure/avm-terraform-governance/actions/runs/31402837924/job/93501906211) installed `Avm.Authoring` 0.5.5, then 0.5.6 became visible before pre-commit executed. The module version guard correctly failed, but the sync had no recovery path.

## Validation

- `pwsh -NoProfile -Command "& './tf-repo-mgmt/scripts/Test-RepositoryConfig.ps1'; & './tf-repo-mgmt/scripts/Test-AvmPreCommit.ps1'"`
- PowerShell parser validation for both modified scripts
- `git diff --check`