### PR TITLE
chore: deprecate legacy Terraform test workflow

### DIFF
--- a/tf-repo-mgmt/repository-config/deprecated-files.json
+++ b/tf-repo-mgmt/repository-config/deprecated-files.json
@@ -20,6 +20,7 @@
     ".github/workflows/grept_cronjob.yml",
     ".github/workflows/linting.yml",
     ".github/workflows/test-examples-template.yml",
+    ".github/workflows/terraform-test.yml",
     ".github/workflows/version-check.yml",
     ".vscode/mcp.json",
     "Makefile",


### PR DESCRIPTION
## Summary

- Add `.github/workflows/terraform-test.yml` to the deprecated-files list.
- Remove the legacy workflow during repository synchronization, including from [terraform-azurerm-avm-res-keyvault-vault](https://github.com/Azure/terraform-azurerm-avm-res-keyvault-vault/blob/main/.github/workflows/terraform-test.yml).

## Validation

- Parsed `deprecated-files.json` successfully with PowerShell.